### PR TITLE
Tidy up use of brand name

### DIFF
--- a/src/how-alerts-work.html
+++ b/src/how-alerts-work.html
@@ -63,7 +63,7 @@
         Emergency alerts are free. You do not need to sign up for them or download an app.
       </p>
       <p class="govuk-body">
-        You can <a class="govuk-link" href="/alerts/opt-out">opt out of Emergency Alerts</a>, but you should keep them switched on for your own safety.
+        You can <a class="govuk-link" href="/alerts/opt-out">opt out of emergency alerts</a>, but you should keep them switched on for your own safety.
       </p>
       <h2 class="govuk-heading-m" id="phone-handsets-and-devices">
         Phone handsets and devices

--- a/src/index.html
+++ b/src/index.html
@@ -69,7 +69,7 @@
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-l">Reasons you might get an&nbsp;alert</h2>
       <p class="govuk-body">
-        The UK government is still testing Emergency Alerts.
+        The UK government is still testing the Emergency Alerts service.
       </p>
       <p class="govuk-body">
         You may get an alert if you live in, or travel through, a test area.

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -3,11 +3,11 @@
 {%- from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs -%}
 {%- from "templates/components/meta_tags.html" import metaTags -%}
 
-{% set pageTitle = "How to opt out of Emergency Alerts" %}
+{% set pageTitle = "How to opt out of emergency alerts" %}
 
 {% block metaTags %}
   {{ metaTags(
-    description="How to turn off Emergency Alerts on Android phones and tablets, iPhones and iPads",
+    description="How to turn off emergency alerts on Android phones and tablets, iPhones and iPads",
     title=pageTitle,
     url="https://www.gov.uk/alerts/opt-out"
   ) }}
@@ -36,7 +36,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        How to opt out of Emergency Alerts
+        How to opt out of emergency alerts
       </h1>
       <p class="govuk-body">
         If you opt out, you will not get any emergency alerts.

--- a/src/reasons-you-might-get-an-alert.html
+++ b/src/reasons-you-might-get-an-alert.html
@@ -39,7 +39,7 @@
         Reasons you might get an emergency alert
       </h1>
       <p class="govuk-body">
-        The UK government is still testing Emergency Alerts.
+        The UK government is still testing the Emergency Alerts service.
       </p>
       <p class="govuk-body">
         If there’s a test in your local area, you might get an alert.

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -49,7 +49,7 @@
         Sometimes an alert will include a phone number or a link to the GOV.UK website for more information.
       </p>
       <div class="govuk-inset-text">
-        <p>The UK government is still testing Emergency Alerts.</p>
+        <p>The UK government is still testing the Emergency Alerts service.</p>
         <p>You may get an alert if you live in, or travel through, a test area.</p>
       </div>
       <h2 class="govuk-heading-m">

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -43,7 +43,7 @@
   {{ govukFooter({
     'navigation': [
       {
-        'title': 'Emergency alerts',
+        'title': 'Emergency Alerts',
         'columns': 2,
         'items': [
           {
@@ -59,7 +59,7 @@
             'href': '/alerts/how-alerts-work'
           },
           {
-            'text': 'Opt out of Emergency Alerts',
+            'text': 'Opt out of emergency alerts',
             'href': '/alerts/opt-out'
           }
         ]


### PR DESCRIPTION
There are a few places where our approach to when to capitalise Emergency Alerts and when not to looks a bit weird.

This PR fixes that by making it more explicit when we’re talking about the service name.

It includes changes to page titles and navigation, so it *might* break some smoke tests.

## The rules are

`Emergency Alerts`

* landing page title
* breadcrumb for landing page
* footer menu heading
* only if we’re explicitly talking about the service, for example: ‘the Emergency Alerts service’

`emergency alerts` or `emergency alert`

* everywhere else

`alerts` or `alert`

* only use after ‘emergency alerts’ to reduce repetition and improve readability