### PR TITLE
Remove example SVG from tab order in IE / Edge

### DIFF
--- a/templates/components/example.html
+++ b/templates/components/example.html
@@ -10,7 +10,7 @@
   {% set alt = 'Mobile phone screen showing an emergency alert. The alert says: ‘' ~ popup_text | join(' ') ~ '’' %}
   <div class="alerts-image__container--centred">
     <!--[if gt IE 8]><!-->
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 315 429" role="img" class="example alerts-image__image--centred">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 315 429" focusable="false" role="img" class="example alerts-image__image--centred">
       <defs>
         <linearGradient id="screenGradient" gradientTransform="rotate(80)">
           <stop id="stop1" offset="0%" stop-color="#1b70b8" />


### PR DESCRIPTION
Internet Explorer and Microsoft Edge up to version 13 treat SVGs as interactive elements and include them in the `tabindex` unless they have `focusable="false"`.

Add `focusable="false"` to the example SVG so that it's not included when tabbing in these browsers – at the minute if you tab forwards from the 'What happens when you get an alert' link it gets focused, but does not have a visible focus state so the focus appears 'lost'.