### PR TITLE
Update privacy notice

### DIFF
--- a/src/privacy-notice.html
+++ b/src/privacy-notice.html
@@ -90,10 +90,10 @@
         Emergency Alerts feedback survey
       </h3>
       <p class="govuk-body">
-        The UK government is still testing Emergency Alerts. If you are in a test area and receive a test alert, you may want to complete the feedback survey.
+        The UK government is still testing the Emergency Alerts service. If you are in a test area and receive a test alert, you may want to complete the feedback survey.
       </p>
       <p class="govuk-body">
-        The survey asks questions about your experience of Emergency Alerts.
+        The survey asks questions about your experience of receiving an emergency alert.
       </p>
       <p class="govuk-body">
         At the end of the survey you’ll be asked if you would like to take part in user research. If you say yes, you will be asked to enter your email address.

--- a/src/privacy-notice.html
+++ b/src/privacy-notice.html
@@ -96,7 +96,7 @@
         The survey asks questions about your experience of Emergency Alerts.
       </p>
       <p class="govuk-body">
-        Question 7 asks if you want to take part in user research. If you say yes, you’ll be asked to enter your email address.
+        At the end of the survey you’ll be asked if you would like to take part in user research. If you say yes, you will be asked to enter your email address.
       </p>
       <p class="govuk-body">
         The rest of the questions do not ask you for personal information. Please do not enter anything that could be used to identify you – for example, your name, address or phone number.
@@ -321,7 +321,7 @@
         If these changes affect how your personal data is processed, GDS will take reasonable steps to let you know.
       </p>
       <p class="govuk-body">
-        Last updated 16 May 2021
+        Last updated 17 May 2021
       </p>
     </div>
   </div>


### PR DESCRIPTION
This PR updates the privacy statement to:

- amend information about taking part in future user research
- make the use of the Emergency Alerts brand name consistent with the rest of the site content
- update the last reviewed date