### PR TITLE
Update iPhone instructions

### DIFF
--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -85,7 +85,10 @@
       {% endset %}
       {% set iosAdvice %}
         <p class="govuk-body">
-            Swipe down from the top of the screen to view your notifications. If you clear your notifications you’ll delete the alert.
+            On the lock screen, swipe up from the middle of the screen to see your notifications. If your device is unlocked, swipe down from the top centre.
+        </p>
+        <p class="govuk-body">
+            If you clear your notifications you’ll delete the alert.
         </p>
       {% endset %}
       {{ govukDetails({

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -85,7 +85,7 @@
       {% endset %}
       {% set iosAdvice %}
         <p class="govuk-body">
-            Swipe down on the home screen to view your notifications. If you clear your notifications you’ll delete the alert.
+            Swipe down from the top of the screen to view your notifications. If you clear your notifications you’ll delete the alert.
         </p>
       {% endset %}
       {{ govukDetails({


### PR DESCRIPTION
This PR updates the iPhone instructions based on feedback received on Twitter:

> Can I make a suggestion for http://gov.uk/alerts/when-you-get-an-alert? The iPhone instructions say “swipe down on the Home Screen”, but that’ll open Spotlight search if you swipe in the middle. A more reliable instruction would be “swipe down from the top of the screen”. Nice pages, very clear!

Would be great if at least 1 iPhone user could check this.