### PR TITLE
Fix visual bug with example SVG in IE11

### DIFF
--- a/src/assets/stylesheets/components/example.scss
+++ b/src/assets/stylesheets/components/example.scss
@@ -3,8 +3,11 @@
 
 .example {
   display: block;
-  max-width: 315px;
-  @include govuk-media-query($until: tablet) {
-    max-width: 270px;
+
+  // instead of swapping at the $tablet breakpoint keep it small until
+  // 720px, when its column is wide enough to contain the larger size
+  @include govuk-media-query($until: 720px) {
+    width: 270px;
+    height: 368px;
   }
 }

--- a/templates/components/example.html
+++ b/templates/components/example.html
@@ -10,7 +10,7 @@
   {% set alt = 'Mobile phone screen showing an emergency alert. The alert says: ‘' ~ popup_text | join(' ') ~ '’' %}
   <div class="alerts-image__container--centred">
     <!--[if gt IE 8]><!-->
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 315 429" focusable="false" role="img" class="example alerts-image__image--centred">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 315 429" focusable="false" height="429" width="315" role="img" class="example alerts-image__image--centred">
       <defs>
         <linearGradient id="screenGradient" gradientTransform="rotate(80)">
           <stop id="stop1" offset="0%" stop-color="#1b70b8" />


### PR DESCRIPTION
In IE9-11, it looks like removing the height and width attributes from the SVG made it render much smaller than it should be.

<img width="982" alt="ie11_before" src="https://user-images.githubusercontent.com/87140/118885468-b6e3a980-b8ef-11eb-984d-f078072808e4.png">

This replaces those attributes and rewrites the mobile breakpoint so it matches the intended size while maintaining the same aspect ratio.

## After the fix

### IE11

<img width="995" alt="ie11_after" src="https://user-images.githubusercontent.com/87140/118885580-e0043a00-b8ef-11eb-9648-1c91b415212a.png">

### Chrome

|Desktop|Mobile|
|---|---|
|<img width="996" alt="with_max_height_desktop" src="https://user-images.githubusercontent.com/87140/118886271-a08a1d80-b8f0-11eb-92a6-5b80476d233d.png">|<img width="375" alt="iphone_8_chrome_emulation" src="https://user-images.githubusercontent.com/87140/118886299-a97aef00-b8f0-11eb-895e-09f377ece35d.png">|

