### PR TITLE
Add survey component

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -2,7 +2,7 @@
 
 {% block pageTitleCurrent %}Content not found{% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/src/alert.html
+++ b/src/alert.html
@@ -44,7 +44,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl alerts-icon__container alerts-icon__container--48">
     {{ alerts_icon(height=48, alert_active=alert_data.is_current) }}
     {{ alert_data.headline }}

--- a/src/assets/stylesheets/_extensions.scss
+++ b/src/assets/stylesheets/_extensions.scss
@@ -1,0 +1,3 @@
+.govuk-footer {
+  border-top: govuk-spacing(2) solid govuk-colour('blue');
+}

--- a/src/assets/stylesheets/components/survey.scss
+++ b/src/assets/stylesheets/components/survey.scss
@@ -33,6 +33,9 @@
 }
 
 .alerts-feedback__prompt-question > .govuk-link {
+
+  //white-space: nowrap;
+
   &,
   &:active {
     color: govuk-colour("white");

--- a/src/assets/stylesheets/components/survey.scss
+++ b/src/assets/stylesheets/components/survey.scss
@@ -1,0 +1,36 @@
+@import "govuk/settings/all";
+@import "govuk/helpers/all";
+
+.alerts-feedback {
+  margin-top: govuk-spacing(6);
+  margin-bottom: govuk-spacing(4) * -1;
+  border-bottom: 1px solid govuk-colour("white");
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(9);
+    margin-bottom: govuk-spacing(7) * -1;
+  }
+
+  &__prompt {
+    text-align: center;
+    background-color: govuk-colour("blue");
+    padding: govuk-spacing(5) govuk-spacing(5) govuk-spacing(5) govuk-spacing(5);
+    outline: 0;
+
+    @include govuk-media-query($from: tablet) {
+      text-align: left;
+    }
+  }
+
+  &__prompt-question {
+    margin: govuk-spacing(2) govuk-spacing(4);
+
+    @include govuk-media-query($from: tablet) {
+      margin-left: 0;
+    }
+
+    &, & > .govuk-link {
+      color: govuk-colour("white");
+    }
+  }
+}

--- a/src/assets/stylesheets/components/survey.scss
+++ b/src/assets/stylesheets/components/survey.scss
@@ -24,13 +24,21 @@
 
   &__prompt-question {
     margin: govuk-spacing(2) govuk-spacing(4);
+    color: govuk-colour("white");
 
     @include govuk-media-query($from: tablet) {
       margin-left: 0;
     }
+  }
+}
 
-    &, & > .govuk-link {
-      color: govuk-colour("white");
-    }
+.alerts-feedback__prompt-question > .govuk-link {
+  &,
+  &:active {
+    color: govuk-colour("white");
+  }
+
+  &:focus {
+    color: $govuk-focus-text-colour;
   }
 }

--- a/src/assets/stylesheets/main.scss
+++ b/src/assets/stylesheets/main.scss
@@ -6,3 +6,4 @@
 @import "components/example";
 @import "components/survey";
 @import "globals";
+@import "extensions";

--- a/src/assets/stylesheets/main.scss
+++ b/src/assets/stylesheets/main.scss
@@ -4,4 +4,5 @@
 @import "components/image";
 @import "components/alert";
 @import "components/example";
+@import "components/survey";
 @import "globals";

--- a/src/current-alerts.html
+++ b/src/current-alerts.html
@@ -37,7 +37,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">
     Current alerts
   </h1>

--- a/src/how-alerts-work.html
+++ b/src/how-alerts-work.html
@@ -32,7 +32,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,6 @@
 {%- from "templates/components/image.html" import image -%}
 {%- from "templates/components/example.html" import example -%}
 {%- from "templates/components/meta_tags.html" import metaTags -%}
-{%- from "templates/components/survey.html" import survey -%}
 
 {% set pageTitle = "Emergency Alerts" %}
 
@@ -36,7 +35,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">
     Emergency Alerts
   </h1>
@@ -107,7 +106,6 @@
       </p>
     </div>
   </div>
-  {{ survey() }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
 {%- from "templates/components/image.html" import image -%}
 {%- from "templates/components/example.html" import example -%}
 {%- from "templates/components/meta_tags.html" import metaTags -%}
+{%- from "templates/components/survey.html" import survey -%}
 
 {% set pageTitle = "Emergency Alerts" %}
 
@@ -106,6 +107,7 @@
       </p>
     </div>
   </div>
+  {{ survey() }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -32,7 +32,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -32,7 +32,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/src/privacy-notice.html
+++ b/src/privacy-notice.html
@@ -17,7 +17,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/src/reasons-you-might-get-an-alert.html
+++ b/src/reasons-you-might-get-an-alert.html
@@ -32,7 +32,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -33,7 +33,7 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -1,5 +1,7 @@
 {% extends "govuk_frontend_jinja/template.html" %}
 
+{%- from "templates/components/survey.html" import survey -%}
+
 {% block pageTitle %}{% block pageTitleCurrent %}{% endblock %} - GOV.UK{% endblock %}
 
 {% block headIcons %}
@@ -37,6 +39,11 @@
   {{ govukHeader({
     'assetsPath': '/alerts/assets/images'
   }) }}
+{% endblock %}
+
+{% block content %}
+  {% block mainContent %}{% endblock %}
+  {{ survey() }}
 {% endblock %}
 
 {% block footer %}

--- a/templates/components/survey.html
+++ b/templates/components/survey.html
@@ -1,0 +1,12 @@
+{% macro survey() %}
+<div class="alerts-feedback govuk-!-display-none-print">
+  <div class="alerts-feedback__prompt">
+    <h2 class="alerts-feedback__prompt-heading govuk-visually-hidden">
+      Help us improve GOV.UK
+    </h2>
+    <p class="alerts-feedback__prompt-question govuk-body">
+      Please fill in <a class="govuk-link govuk-link--no-visited-state" href="https://surveys.publishing.service.gov.uk/s/emergencyalertsurvey/">our survey</a>
+    </p>
+  </div>
+</div>
+{% endmacro %}

--- a/templates/components/survey.html
+++ b/templates/components/survey.html
@@ -5,7 +5,7 @@
       Help us improve GOV.UK
     </h2>
     <p class="alerts-feedback__prompt-question govuk-body">
-      Please fill in <a class="govuk-link govuk-link--no-visited-state" href="https://surveys.publishing.service.gov.uk/s/emergencyalertsurvey/">our survey</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="https://surveys.publishing.service.gov.uk/s/emergencyalertsurvey/">Give feedback about Emergency&nbsp;Alerts</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Adds a survey component, loosely based on [GOVUK's feedback component](https://components.publishing.service.gov.uk/component-guide/feedback).

https://www.pivotaltracker.com/story/show/177726051

|Desktop|Mobile|
|---|---|
|<img width="1090" alt="survey_desktop" src="https://user-images.githubusercontent.com/87140/118981788-a6c0de00-b972-11eb-888d-730955ef1177.png">|<img width="374" alt="survey_mobile" src="https://user-images.githubusercontent.com/87140/118981816-acb6bf00-b972-11eb-9179-1f90d8ceed59.png">|

Currently contains fake content so I'm leaving this in draft until @karlchillmaid can write something real for it.

## Notes for reviewers

I've checked on all browsers in our matrix and the link in it has been checked against the [GOVUK feedback component's accessibility criteria](https://components.publishing.service.gov.uk/component-guide/feedback).

GOVUK's sits outside the `<main>` element. That would require some slightly hacky workarounds for us because the GOVUK Frontend template, which we use for our layout, doesn't have a slot for that point in the HTML. Because of this, I've included it in the `<main>` element which, I think, has relatively low impact on the structure of the document.

It includes a hidden `<h2>`, which was a suggestion by the GOVUK accessibility team to make it easier to find in the document structure for non-visual users.

This PR also adds a blue border to the top of the footer to match that on the rest of www.gov.uk.