### PR TITLE
Update content for ‘How to opt out of emergency alerts’

### DIFF
--- a/src/how-alerts-work.html
+++ b/src/how-alerts-work.html
@@ -63,7 +63,7 @@
         Emergency alerts are free. You do not need to sign up for them or download an app.
       </p>
       <p class="govuk-body">
-        You can <a class="govuk-link" href="/alerts/opt-out">opt out of emergency alerts</a>, but you should keep them switched on for your own safety.
+        You can <a class="govuk-link" href="/alerts/opt-out">opt out of some emergency alerts</a>, but you should keep them switched on for your own safety.
       </p>
       <h2 class="govuk-heading-m" id="phone-handsets-and-devices">
         Phone handsets and devices

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -39,10 +39,10 @@
         How to opt out of emergency alerts
       </h1>
       <p class="govuk-body">
-        If you opt out, you will not get any emergency alerts.
+        You can opt out of some emergency alerts, but you’ll always get the most important ones.
       </p>
       <p class="govuk-body">
-        You cannot choose the type of hazard you want to get alerts about. If you opt out because you do not want flood warnings for example, you’ll also miss alerts for fires and terrorist incidents.
+        You cannot opt out by subject, only by how serious the emergency is. If you opt out because you do not want flood warnings, for example, you’ll also miss alerts for fires and terrorism.
       </p>
       <p class="govuk-body">
         Because of this, you should keep emergency alerts switched on for your own safety.

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -39,7 +39,7 @@
         How to opt out of emergency alerts
       </h1>
       <p class="govuk-body">
-        You can opt out of some emergency alerts, but you’ll always get the most important ones.
+        You can opt out of some emergency alerts, but not the most important ones.
       </p>
       <p class="govuk-body">
         You cannot opt out by subject, only by how serious the emergency is. If you opt out because you do not want flood warnings, for example, you’ll also miss alerts for fires and terrorism.

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -42,7 +42,7 @@
         You can opt out of some emergency alerts, but not the most important ones.
       </p>
       <p class="govuk-body">
-        You cannot opt out by subject, only by how serious the emergency is. If you opt out because you do not want flood warnings, for example, you’ll also miss alerts for fires and terrorism.
+        You cannot opt out by subject, only by how serious the emergency is. If you opt out because you do not want flood warnings, for example, you might miss alerts for fires and terrorism.
       </p>
       <p class="govuk-body">
         Because of this, you should keep emergency alerts switched on for your own safety.


### PR DESCRIPTION
This PR updates the introduction to the opt out page.

We’re making this change because it’s no longer true to say that users can opt out of all alerts.

## Background
The 25 May test will be sent on the ‘severe’ and ‘government’ channels – the latter of which is mandatory.

Currently we do not mention the ‘government’ channel because:

- explaining the different channels makes the content more complex
- the policy decision about if and when ‘government’ alert will not happen until after the East Suffolk test

Until that decision is made we do not want to introduce an explanation of the channels. However, we should update the content so it’s closer to the statement given to the press, which said:

> “It will be possible to opt-out of some alerts through the phone's settings. However, the most important alerts will always come through and the government recommends that people do not opt-out.”
