### PR TITLE
Test that dates in alert data have correct time offsets

### DIFF
--- a/tests/test_data_yaml.py
+++ b/tests/test_data_yaml.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 import pytest
+import pytz
 
 from lib.alerts import Alerts
 from lib.utils import REPO
@@ -13,3 +16,18 @@ def test_alert_sent_before_starts_before_expires(alerts):
     for alert in alerts:
         assert alert.sent_date.as_utc_datetime <= alert.starts_date.as_utc_datetime
         assert alert.starts_date.as_utc_datetime < alert.expires_date.as_utc_datetime
+
+
+def is_date_in_london_timezone_including_summertime(date):
+    if not isinstance(date, datetime):
+        return False
+    zoneless_date = date.replace(tzinfo=None)
+    date_with_expected_offset = pytz.timezone('Europe/London').localize(zoneless_date)
+    return date_with_expected_offset.utcoffset() == date.utcoffset()
+
+
+def test_dates_in_alerts_data_include_explicit_timezone_offset(alerts):
+    for alert in alerts:
+        assert is_date_in_london_timezone_including_summertime(alert.sent)
+        assert is_date_in_london_timezone_including_summertime(alert.starts)
+        assert is_date_in_london_timezone_including_summertime(alert.expires)


### PR DESCRIPTION
So that they respect daylight saving time changes.

This implements following decision:

Make all timestamps iso 8601, local to the Europe/London with an explicit offset*.

For example: 10:00am on 12 March 2021, which is outside of British Summer Time (BST)
would be:
2021-03-12T10:00+00:00

Whereas 10:00am on 12 May 2021, which is inside BST would be:
2021-05-12T10:00+01:00

This would be enforced by:

a test that checks all the timestamps in data.yaml
an example alert which explains the format used and variations to consider
*following the formatting rules in
https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators

Pivotal ticket: https://www.pivotaltracker.com/story/show/178198145