### PR TITLE
Refactor data handling to support previous alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ bootstrap:
 
 .PHONY: test
 test:
-	isort --check-only *.py
+	isort --check-only *.py lib tests
 	flake8 .
 	npm test
 	pytest tests/

--- a/build.py
+++ b/build.py
@@ -8,12 +8,12 @@ from jinja2 import (
 )
 from notifications_utils.formatters import formatted_list
 
+from lib.alert_date import AlertDate
 from lib.utils import (
     DIST,
     REPO,
     ROOT,
     SRC,
-    AlertsDate,
     convert_dates,
     file_fingerprint,
     is_current_alert,
@@ -39,7 +39,7 @@ env.globals = {
         item.relative_to(DIST)
         for item in ROOT.glob('assets/fonts/*.woff2')
     ],
-    'data_last_updated': AlertsDate(data['last_updated']),
+    'data_last_updated': AlertDate(data['last_updated']),
     'current_alerts': [convert_dates(alert) for alert in data['alerts'] if is_current_alert(alert)]
 }
 

--- a/build.py
+++ b/build.py
@@ -1,4 +1,3 @@
-import yaml
 from jinja2 import (
     ChoiceLoader,
     Environment,
@@ -8,8 +7,7 @@ from jinja2 import (
 )
 from notifications_utils.formatters import formatted_list
 
-from lib.alert import Alert
-from lib.alert_date import AlertDate
+from lib.alerts import Alerts
 from lib.utils import DIST, REPO, ROOT, SRC, file_fingerprint
 
 jinja_loader = ChoiceLoader([
@@ -20,13 +18,7 @@ jinja_loader = ChoiceLoader([
 ])
 
 
-data_file = REPO / 'data.yaml'
-with data_file.open() as stream:
-    data = yaml.load(stream, Loader=yaml.CLoader)
-
-alerts = []
-for alert_dict in data['alerts']:
-    alerts += [Alert(alert_dict)]
+alerts = Alerts.from_yaml(REPO / 'data.yaml')
 
 env = Environment(loader=jinja_loader, autoescape=True)
 env.filters['file_fingerprint'] = file_fingerprint
@@ -36,7 +28,7 @@ env.globals = {
         item.relative_to(DIST)
         for item in ROOT.glob('assets/fonts/*.woff2')
     ],
-    'data_last_updated': AlertDate(data['last_updated']),
+    'data_last_updated': alerts.last_updated_date,
     'current_alerts': [alert for alert in alerts if alert.is_current]
 }
 

--- a/build.py
+++ b/build.py
@@ -8,16 +8,9 @@ from jinja2 import (
 )
 from notifications_utils.formatters import formatted_list
 
-from lib.alert_date import AlertDate
 from lib.alert import Alert
-from lib.utils import (
-    DIST,
-    REPO,
-    ROOT,
-    SRC,
-    file_fingerprint,
-    is_current_alert,
-)
+from lib.alert_date import AlertDate
+from lib.utils import DIST, REPO, ROOT, SRC, file_fingerprint
 
 jinja_loader = ChoiceLoader([
     FileSystemLoader(str(REPO)),
@@ -44,7 +37,7 @@ env.globals = {
         for item in ROOT.glob('assets/fonts/*.woff2')
     ],
     'data_last_updated': AlertDate(data['last_updated']),
-    'current_alerts': [alert for alert in alerts if is_current_alert(alert)]
+    'current_alerts': [alert for alert in alerts if alert.is_current]
 }
 
 if __name__ == '__main__':

--- a/build.py
+++ b/build.py
@@ -31,6 +31,9 @@ data_file = REPO / 'data.yaml'
 with data_file.open() as stream:
     data = yaml.load(stream, Loader=yaml.CLoader)
 
+for alert in data['alerts']:
+    convert_dates(alert)
+
 env = Environment(loader=jinja_loader, autoescape=True)
 env.filters['file_fingerprint'] = file_fingerprint
 env.filters['formatted_list'] = formatted_list
@@ -40,7 +43,7 @@ env.globals = {
         for item in ROOT.glob('assets/fonts/*.woff2')
     ],
     'data_last_updated': AlertDate(data['last_updated']),
-    'current_alerts': [convert_dates(alert) for alert in data['alerts'] if is_current_alert(alert)]
+    'current_alerts': [alert for alert in data['alerts'] if is_current_alert(alert)]
 }
 
 if __name__ == '__main__':

--- a/build.py
+++ b/build.py
@@ -29,7 +29,7 @@ env.globals = {
         for item in ROOT.glob('assets/fonts/*.woff2')
     ],
     'data_last_updated': alerts.last_updated_date,
-    'current_alerts': [alert for alert in alerts if alert.is_current]
+    'current_alerts': alerts.current,
 }
 
 if __name__ == '__main__':

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -1,0 +1,10 @@
+from lib.alert_date import AlertDate
+
+
+class Alert:
+    def __init__(self, dict_):
+        for key, value in dict_.items():
+            setattr(self, key, value)
+
+        self.sent = AlertDate(self.sent)
+        self.expires = AlertDate(self.expires)

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -1,4 +1,6 @@
 from lib.alert_date import AlertDate
+import pytz
+from datetime import datetime
 
 
 class Alert:
@@ -8,3 +10,11 @@ class Alert:
 
         self.sent = AlertDate(self.sent)
         self.expires = AlertDate(self.expires)
+
+    @property
+    def is_current(self):
+        now = datetime.now(pytz.utc)
+
+        if self.expires.as_utc_datetime <= now:
+            return False
+        return True

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -1,22 +1,34 @@
 from datetime import datetime
 
 import pytz
+from notifications_utils.serialised_model import SerialisedModel
 
 from lib.alert_date import AlertDate
 
 
-class Alert:
-    def __init__(self, dict_):
-        for key, value in dict_.items():
-            setattr(self, key, value)
+class Alert(SerialisedModel):
+    ALLOWED_PROPERTIES = {
+        'identifier',
+        'message_type',
+        'sent',
+        'expires',
+        'headline',
+        'description',
+        'area_names',
+    }
 
-        self.sent = AlertDate(self.sent)
-        self.expires = AlertDate(self.expires)
+    @property
+    def sent_date(self):
+        return AlertDate(self.sent)
+
+    @property
+    def expires_date(self):
+        return AlertDate(self.expires)
 
     @property
     def is_current(self):
         now = datetime.now(pytz.utc)
 
-        if self.expires.as_utc_datetime <= now:
+        if self.expires_date.as_utc_datetime <= now:
             return False
         return True

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -1,6 +1,8 @@
-from lib.alert_date import AlertDate
-import pytz
 from datetime import datetime
+
+import pytz
+
+from lib.alert_date import AlertDate
 
 
 class Alert:

--- a/lib/alert_date.py
+++ b/lib/alert_date.py
@@ -1,3 +1,4 @@
+import pytz
 from pytz import timezone
 
 
@@ -17,8 +18,8 @@ class AlertDate(object):
         return self._local_datetime.isoformat()
 
     @property
-    def as_datetime(self):
-        return self._datetime
+    def as_utc_datetime(self):
+        return self._datetime.astimezone(pytz.utc)
 
     @property
     def as_local_datetime(self):

--- a/lib/alert_date.py
+++ b/lib/alert_date.py
@@ -1,0 +1,25 @@
+from pytz import timezone
+
+
+class AlertDate(object):
+    """Makes a datetime available in different formats"""
+
+    def __init__(self, _datetime):
+        self._datetime = _datetime
+        self._local_datetime = _datetime.astimezone(timezone('Europe/London'))
+
+    @property
+    def as_lang(self, lang='en-GB'):
+        return '{dt.day} {dt:%B} {dt:%Y} at {dt:%H}:{dt:%M}'.format(dt=self._local_datetime)
+
+    @property
+    def as_iso8601(self):
+        return self._local_datetime.isoformat()
+
+    @property
+    def as_datetime(self):
+        return self._datetime
+
+    @property
+    def as_local_datetime(self):
+        return self._local_datetime

--- a/lib/alerts.py
+++ b/lib/alerts.py
@@ -1,0 +1,24 @@
+import yaml
+from notifications_utils.serialised_model import SerialisedModelCollection
+
+from lib.alert import Alert
+from lib.alert_date import AlertDate
+
+
+class Alerts(SerialisedModelCollection):
+    model = Alert
+
+    def __init__(self, data):
+        self.last_updated = data['last_updated']
+        super().__init__(data['alerts'])
+
+    @property
+    def last_updated_date(self):
+        return AlertDate(self.last_updated)
+
+    @classmethod
+    def from_yaml(cls, path):
+        with path.open() as stream:
+            data = yaml.load(stream, Loader=yaml.CLoader)
+
+        return cls(data)

--- a/lib/alerts.py
+++ b/lib/alerts.py
@@ -13,6 +13,10 @@ class Alerts(SerialisedModelCollection):
         super().__init__(data['alerts'])
 
     @property
+    def current(self):
+        return [alert for alert in self if alert.is_current]
+
+    @property
     def last_updated_date(self):
         return AlertDate(self.last_updated)
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -2,37 +2,13 @@ import hashlib
 import pytz
 from datetime import datetime
 from pathlib import Path
-from pytz import timezone
+from lib.alert_date import AlertDate
 
 
 REPO = Path('.')
 SRC = REPO / 'src'
 DIST = REPO / 'dist'
 ROOT = DIST / 'alerts'
-
-
-class AlertsDate(object):
-    """Makes a datetime available in different formats"""
-
-    def __init__(self, _datetime):
-        self._datetime = _datetime
-        self._local_datetime = _datetime.astimezone(timezone('Europe/London'))
-
-    @property
-    def as_lang(self, lang='en-GB'):
-        return '{dt.day} {dt:%B} {dt:%Y} at {dt:%H}:{dt:%M}'.format(dt=self._local_datetime)
-
-    @property
-    def as_iso8601(self):
-        return self._local_datetime.isoformat()
-
-    @property
-    def as_datetime(self):
-        return self._datetime
-
-    @property
-    def as_local_datetime(self):
-        return self._local_datetime
 
 
 def file_fingerprint(path, root=DIST):
@@ -49,6 +25,6 @@ def is_current_alert(alert):
 
 
 def convert_dates(alert):
-    alert['sent'] = AlertsDate(alert['sent'])
-    alert['expires'] = AlertsDate(alert['expires'])
+    alert['sent'] = AlertDate(alert['sent'])
+    alert['expires'] = AlertDate(alert['expires'])
     return alert

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -43,8 +43,6 @@ def file_fingerprint(path, root=DIST):
 def is_current_alert(alert):
     now = datetime.now(pytz.utc)
 
-    if alert['message_type'] == 'cancel':
-        return False
     if alert['expires'].astimezone(pytz.utc) <= now:  # pyyaml converts ISO 8601 dates to datetime.datetime instances
         return False
     return True

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,7 +1,6 @@
 import hashlib
 from pathlib import Path
 
-
 REPO = Path('.')
 SRC = REPO / 'src'
 DIST = REPO / 'dist'

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -19,7 +19,7 @@ def file_fingerprint(path, root=DIST):
 def is_current_alert(alert):
     now = datetime.now(pytz.utc)
 
-    if alert['expires'].astimezone(pytz.utc) <= now:  # pyyaml converts ISO 8601 dates to datetime.datetime instances
+    if alert['expires'].as_utc_datetime <= now:
         return False
     return True
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -2,7 +2,6 @@ import hashlib
 import pytz
 from datetime import datetime
 from pathlib import Path
-from lib.alert_date import AlertDate
 
 
 REPO = Path('.')
@@ -19,12 +18,6 @@ def file_fingerprint(path, root=DIST):
 def is_current_alert(alert):
     now = datetime.now(pytz.utc)
 
-    if alert['expires'].as_utc_datetime <= now:
+    if alert.expires.as_utc_datetime <= now:
         return False
     return True
-
-
-def convert_dates(alert):
-    alert['sent'] = AlertDate(alert['sent'])
-    alert['expires'] = AlertDate(alert['expires'])
-    return alert

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,6 +1,4 @@
 import hashlib
-import pytz
-from datetime import datetime
 from pathlib import Path
 
 
@@ -13,11 +11,3 @@ ROOT = DIST / 'alerts'
 def file_fingerprint(path, root=DIST):
     contents = open(str(root) + path, 'rb').read()
     return path + '?' + hashlib.md5(contents).hexdigest()
-
-
-def is_current_alert(alert):
-    now = datetime.now(pytz.utc)
-
-    if alert.expires.as_utc_datetime <= now:
-        return False
-    return True

--- a/src/alert.html
+++ b/src/alert.html
@@ -51,7 +51,7 @@
         {{ alert_data.description }}
       </p>
       <p class="govuk-body govuk-!-margin-bottom-0">
-        Issued by Cabinet Office <span class="relative-date__prefix">on </span><time class="relative-date" datetime="{{ alert_data.sent.as_iso8601 }}">{{ alert_data.sent.as_lang }}</time>
+        Issued by Cabinet Office <span class="relative-date__prefix">on </span><time class="relative-date" datetime="{{ alert_data.sent_date.as_iso8601 }}">{{ alert_data.sent_date.as_lang }}</time>
       </p>
     </div>
   </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytz
+from datetime import datetime
+import pytest
+
+
+@pytest.fixture()
+def alert_dict():
+    return {
+        'sent': datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc),
+        'expires': datetime(2021, 4, 21, 12, 30, tzinfo=pytz.utc)
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,11 @@ import pytz
 @pytest.fixture()
 def alert_dict():
     return {
+        'headline': 'Emergency alert',
+        'description': 'Something',
+        'area_names': [],
+        'message_type': 'alert',
+        'identifier': '1234',
         'sent': datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc),
         'expires': datetime(2021, 4, 21, 12, 30, tzinfo=pytz.utc)
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
-import pytz
 from datetime import datetime
+
 import pytest
+import pytz
 
 
 @pytest.fixture()

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -1,7 +1,10 @@
 from lib.alert import Alert
 import pytz
+import pytest
 
 from datetime import datetime
+from freezegun import freeze_time
+
 from lib.alert_date import AlertDate
 
 
@@ -9,3 +12,15 @@ def test_init_converts_alert_sent_and_expiry_dates_to_AlertDate_class(alert_dict
     alert = Alert(alert_dict)
     assert isinstance(alert.sent, AlertDate)
     assert isinstance(alert.expires, AlertDate)
+
+
+@pytest.mark.parametrize('expiry_date,is_current', [
+    [datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc), True],
+    [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), False],
+])
+@freeze_time(datetime(
+    2021, 4, 21, 10, 30, tzinfo=pytz.utc
+))
+def test_is_current_alert_checks_if_alert_is_current(expiry_date, is_current, alert_dict):
+    alert_dict['expires'] = expiry_date
+    assert Alert(alert_dict).is_current == is_current

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -8,10 +8,10 @@ from lib.alert import Alert
 from lib.alert_date import AlertDate
 
 
-def test_init_converts_alert_sent_and_expiry_dates_to_AlertDate_class(alert_dict):
+def test_alert_sent_and_expiry_properties_are_AlertDates(alert_dict):
     alert = Alert(alert_dict)
-    assert isinstance(alert.sent, AlertDate)
-    assert isinstance(alert.expires, AlertDate)
+    assert isinstance(alert.sent_date, AlertDate)
+    assert isinstance(alert.expires_date, AlertDate)
 
 
 @pytest.mark.parametrize('expiry_date,is_current', [

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -1,0 +1,11 @@
+from lib.alert import Alert
+import pytz
+
+from datetime import datetime
+from lib.alert_date import AlertDate
+
+
+def test_init_converts_alert_sent_and_expiry_dates_to_AlertDate_class(alert_dict):
+    alert = Alert(alert_dict)
+    assert isinstance(alert.sent, AlertDate)
+    assert isinstance(alert.expires, AlertDate)

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -1,10 +1,10 @@
-from lib.alert import Alert
-import pytz
-import pytest
-
 from datetime import datetime
+
+import pytest
+import pytz
 from freezegun import freeze_time
 
+from lib.alert import Alert
 from lib.alert_date import AlertDate
 
 

--- a/tests/test_alert_date.py
+++ b/tests/test_alert_date.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from lib.alert_date import AlertDate
+from pytz import timezone
+import pytz
+
+
+def test_AlertDate_properties():
+    sample_datetime = datetime(2021, 3, 21, 10, 30, tzinfo=pytz.utc)
+    alerts_date = AlertDate(sample_datetime)
+    assert alerts_date.as_lang == '21 March 2021 at 10:30'
+    assert alerts_date.as_iso8601 == '2021-03-21T10:30:00+00:00'
+    assert alerts_date.as_datetime == sample_datetime
+    assert alerts_date.as_local_datetime == sample_datetime  # sample date is outside of British Summer Time (BST)
+
+
+def test_AlertDate_properties_work_with_bst():
+    datetime_in_bst = datetime(2021, 4, 21, 10, 30, tzinfo=pytz.utc)
+    alerts_date = AlertDate(datetime_in_bst)
+    assert alerts_date.as_lang == '21 April 2021 at 11:30'
+    assert alerts_date.as_iso8601 == '2021-04-21T11:30:00+01:00'
+    assert alerts_date.as_datetime == datetime_in_bst.astimezone(timezone('Europe/London'))

--- a/tests/test_alert_date.py
+++ b/tests/test_alert_date.py
@@ -9,13 +9,15 @@ def test_AlertDate_properties():
     alerts_date = AlertDate(sample_datetime)
     assert alerts_date.as_lang == '21 March 2021 at 10:30'
     assert alerts_date.as_iso8601 == '2021-03-21T10:30:00+00:00'
-    assert alerts_date.as_datetime == sample_datetime
-    assert alerts_date.as_local_datetime == sample_datetime  # sample date is outside of British Summer Time (BST)
+    assert alerts_date.as_utc_datetime == sample_datetime
+    assert alerts_date.as_local_datetime == sample_datetime
 
 
 def test_AlertDate_properties_work_with_bst():
-    datetime_in_bst = datetime(2021, 4, 21, 10, 30, tzinfo=pytz.utc)
+    sample_datetime = datetime(2021, 4, 21, 10, 30, tzinfo=pytz.utc)
+    datetime_in_bst = sample_datetime.astimezone(timezone('Europe/London'))
     alerts_date = AlertDate(datetime_in_bst)
     assert alerts_date.as_lang == '21 April 2021 at 11:30'
     assert alerts_date.as_iso8601 == '2021-04-21T11:30:00+01:00'
-    assert alerts_date.as_datetime == datetime_in_bst.astimezone(timezone('Europe/London'))
+    assert alerts_date.as_utc_datetime == sample_datetime
+    assert alerts_date.as_local_datetime == datetime_in_bst

--- a/tests/test_alert_date.py
+++ b/tests/test_alert_date.py
@@ -1,7 +1,9 @@
 from datetime import datetime
-from lib.alert_date import AlertDate
-from pytz import timezone
+
 import pytz
+from pytz import timezone
+
+from lib.alert_date import AlertDate
 
 
 def test_AlertDate_properties():

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+import pytest
+import pytz
+import yaml
+
+from lib.alert import Alert
+from lib.alert_date import AlertDate
+from lib.alerts import Alerts
+
+
+def test_from_yaml_loads_data(tmp_path, alert_dict):
+    sample_yaml = yaml.dump({
+        'last_updated': datetime(2020, 1, 1, 10, 00),
+        'alerts': [alert_dict]
+    })
+
+    data_file = tmp_path / 'data.yaml'
+    data_file.write_text(sample_yaml)
+
+    alerts = Alerts.from_yaml(data_file)
+    assert len(alerts) == 1
+    assert isinstance(alerts[0], Alert)
+    assert isinstance(alerts.last_updated_date, AlertDate)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ import pytz
 
 from datetime import datetime
 from freezegun import freeze_time
-from lib.utils import convert_dates, file_fingerprint, is_current_alert
-from lib.alert_date import AlertDate
+from lib.utils import file_fingerprint, is_current_alert
+from lib.alert import Alert
 from pathlib import Path
 
 
@@ -20,18 +20,6 @@ def test_file_fingerprint_adds_hash_to_file_path():
 @freeze_time(datetime(
     2021, 4, 21, 10, 30, tzinfo=pytz.utc
 ))
-def test_is_current_alert_checks_if_alert_is_current(expiry_date, is_current):
-    alert = {'expires': expiry_date}
-    assert is_current_alert(alert) == is_current
-
-
-def test_convert_dates_converts_alert_sent_and_expiry_dates_to_AlertDate_class():
-    alert = {
-        'message_type': 'alert',
-        'expires': datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc),
-        'sent': datetime(2021, 4, 20, 9, 30, tzinfo=pytz.utc),
-    }
-    converted_alert = convert_dates(alert)
-
-    assert isinstance(converted_alert['sent'], AlertDate)
-    assert isinstance(converted_alert['expires'], AlertDate)
+def test_is_current_alert_checks_if_alert_is_current(expiry_date, is_current, alert_dict):
+    alert_dict['expires'] = expiry_date
+    assert is_current_alert(Alert(alert_dict)) == is_current

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,25 +1,7 @@
-import pytest
-import pytz
-
-from datetime import datetime
-from freezegun import freeze_time
-from lib.utils import file_fingerprint, is_current_alert
-from lib.alert import Alert
+from lib.utils import file_fingerprint
 from pathlib import Path
 
 
 def test_file_fingerprint_adds_hash_to_file_path():
     new_path = file_fingerprint('/tests/test_files/example.txt', root=Path('.'))
     assert new_path == '/tests/test_files/example.txt?4d93d51945b88325c213640ef59fc50b'
-
-
-@pytest.mark.parametrize('expiry_date,is_current', [
-    [datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc), True],
-    [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), False],
-])
-@freeze_time(datetime(
-    2021, 4, 21, 10, 30, tzinfo=pytz.utc
-))
-def test_is_current_alert_checks_if_alert_is_current(expiry_date, is_current, alert_dict):
-    alert_dict['expires'] = expiry_date
-    assert is_current_alert(Alert(alert_dict)) == is_current

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,19 +30,15 @@ def test_file_fingerprint_adds_hash_to_file_path():
     assert new_path == '/tests/test_files/example.txt?4d93d51945b88325c213640ef59fc50b'
 
 
-@pytest.mark.parametrize('expiry_date,message_type,is_current', [
-    [datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc), 'alert', True],
-    [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), 'alert', False],
-    [datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc), 'cancel', False]
+@pytest.mark.parametrize('expiry_date,is_current', [
+    [datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc), True],
+    [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), False],
 ])
 @freeze_time(datetime(
     2021, 4, 21, 10, 30, tzinfo=pytz.utc
 ))
-def test_is_current_alert_checks_if_alert_is_current(expiry_date, message_type, is_current):
-    alert = {
-        'message_type': message_type,
-        'expires': expiry_date
-    }
+def test_is_current_alert_checks_if_alert_is_current(expiry_date, is_current):
+    alert = {'expires': expiry_date}
     assert is_current_alert(alert) == is_current
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
-from lib.utils import file_fingerprint
 from pathlib import Path
+
+from lib.utils import file_fingerprint
 
 
 def test_file_fingerprint_adds_hash_to_file_path():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,26 +3,9 @@ import pytz
 
 from datetime import datetime
 from freezegun import freeze_time
-from lib.utils import AlertsDate, convert_dates, file_fingerprint, is_current_alert
+from lib.utils import convert_dates, file_fingerprint, is_current_alert
+from lib.alert_date import AlertDate
 from pathlib import Path
-from pytz import timezone
-
-
-def test_AlertsDate_properties():
-    sample_datetime = datetime(2021, 3, 21, 10, 30, tzinfo=pytz.utc)
-    alerts_date = AlertsDate(sample_datetime)
-    assert alerts_date.as_lang == '21 March 2021 at 10:30'
-    assert alerts_date.as_iso8601 == '2021-03-21T10:30:00+00:00'
-    assert alerts_date.as_datetime == sample_datetime
-    assert alerts_date.as_local_datetime == sample_datetime  # sample date is outside of British Summer Time (BST)
-
-
-def test_AlertsDate_properties_work_with_bst():
-    datetime_in_bst = datetime(2021, 4, 21, 10, 30, tzinfo=pytz.utc)
-    alerts_date = AlertsDate(datetime_in_bst)
-    assert alerts_date.as_lang == '21 April 2021 at 11:30'
-    assert alerts_date.as_iso8601 == '2021-04-21T11:30:00+01:00'
-    assert alerts_date.as_datetime == datetime_in_bst.astimezone(timezone('Europe/London'))
 
 
 def test_file_fingerprint_adds_hash_to_file_path():
@@ -42,7 +25,7 @@ def test_is_current_alert_checks_if_alert_is_current(expiry_date, is_current):
     assert is_current_alert(alert) == is_current
 
 
-def test_convert_dates_converts_alert_sent_and_expiry_dates_to_AlertsDate_class():
+def test_convert_dates_converts_alert_sent_and_expiry_dates_to_AlertDate_class():
     alert = {
         'message_type': 'alert',
         'expires': datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc),
@@ -50,5 +33,5 @@ def test_convert_dates_converts_alert_sent_and_expiry_dates_to_AlertsDate_class(
     }
     converted_alert = convert_dates(alert)
 
-    assert isinstance(converted_alert['sent'], AlertsDate)
-    assert isinstance(converted_alert['expires'], AlertsDate)
+    assert isinstance(converted_alert['sent'], AlertDate)
+    assert isinstance(converted_alert['expires'], AlertDate)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178198202

In attempting to add a previous alerts feature I got stuck
because the "is_alert_current" function could only be used
for a limited time, before any rendering took place.

This PR makes a broad refactoring to cut down on the number
of utilities, so all the data and functionality is easier to
find, and always works together.

Please see the commit messages for more details.