### PR TITLE
Lint frontend code as part of test, not build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: build
 build: clean
-	npm run lint
 	npm run build
 	python build.py
 
@@ -21,5 +20,6 @@ bootstrap:
 test:
 	isort --check-only *.py
 	flake8 .
+	npm run lint
 	npm test
 	pytest tests/


### PR DESCRIPTION
This matches where we check Python code with `flake8`. It means you don’t have to spend time waiting for the lint task to run every time you want to rebuild the site.