### PR TITLE
Add a minimal page for previous alerts

### DIFF
--- a/build.py
+++ b/build.py
@@ -28,8 +28,7 @@ env.globals = {
         item.relative_to(DIST)
         for item in ROOT.glob('assets/fonts/*.woff2')
     ],
-    'data_last_updated': alerts.last_updated_date,
-    'current_alerts': alerts.current,
+    'alerts': alerts,
 }
 
 if __name__ == '__main__':

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -29,6 +29,7 @@ class Alert(SerialisedModel):
     def is_current(self):
         now = datetime.now(pytz.utc)
 
-        if self.expires_date.as_utc_datetime <= now:
-            return False
-        return True
+        return (
+            self.expires_date.as_utc_datetime >= now and
+            self.sent_date.as_utc_datetime <= now
+        )

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -26,6 +26,11 @@ class Alert(SerialisedModel):
         return AlertDate(self.expires)
 
     @property
+    def is_expired(self):
+        now = datetime.now(pytz.utc)
+        return self.expires_date.as_utc_datetime < now
+
+    @property
     def is_current(self):
         now = datetime.now(pytz.utc)
 

--- a/lib/alerts.py
+++ b/lib/alerts.py
@@ -17,6 +17,10 @@ class Alerts(SerialisedModelCollection):
         return [alert for alert in self if alert.is_current]
 
     @property
+    def expired(self):
+        return [alert for alert in self if alert.is_expired]
+
+    @property
     def last_updated_date(self):
         return AlertDate(self.last_updated)
 

--- a/src/alert.html
+++ b/src/alert.html
@@ -21,6 +21,12 @@
   {{ pageTitle }}
 {%- endblock %}
 
+{% if alert_data.is_expired %}
+  {% set parentBreadcrumb = {"text": "Past alerts", "href": "/alerts/past-alerts"} %}
+{% else %}
+  {% set parentBreadcrumb = {"text": "Current alerts", "href": "/alerts/current-alerts"} %}
+{% endif %}
+
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
@@ -32,17 +38,14 @@
         "text": "Emergency alerts",
         "href": "/alerts"
       },
-      {
-        "text": "Current alerts",
-        "href": "/alerts/current-alerts"
-      }
+      parentBreadcrumb,
     ]
   }) }}
 {% endblock %}
 
 {% block content %}
   <h1 class="govuk-heading-xl alerts-icon__container alerts-icon__container--48">
-    {{ alerts_icon(height=48) }}
+    {{ alerts_icon(height=48, alert_active=alert_data.is_current) }}
     {{ alert_data.headline }}
   </h1>
   <div class="govuk-grid-row">

--- a/src/current-alerts.html
+++ b/src/current-alerts.html
@@ -43,10 +43,7 @@
   </h1>
   {% for current_alert in current_alerts %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  {{ alert(
-    areas=current_alert.area_names,
-    message=current_alert.description,
-    identifier=current_alert.identifier) }}
+  {{ alert(alert=current_alert) }}
   {% endfor %}
   {% if current_alerts %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/src/current-alerts.html
+++ b/src/current-alerts.html
@@ -41,11 +41,11 @@
   <h1 class="govuk-heading-xl">
     Current alerts
   </h1>
-  {% for current_alert in current_alerts %}
+  {% for current_alert in alerts.current %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ alert(alert=current_alert) }}
   {% endfor %}
-  {% if current_alerts %}
+  {% if alerts.current %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">
   {% else %}
   <p class="govuk-body">There are no alerts currently being sent.</p>

--- a/src/index.html
+++ b/src/index.html
@@ -39,9 +39,9 @@
   <h1 class="govuk-heading-xl">
     Emergency Alerts
   </h1>
-  {% if current_alerts %}
+  {% if alerts.current %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  {{ banner(current_alerts | length, data_last_updated) }}
+  {{ banner(alerts.current | length, alerts.last_updated_date) }}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     {{ planned_tests_banner(1, "Tuesday 25 May") }}

--- a/src/past-alerts.html
+++ b/src/past-alerts.html
@@ -1,0 +1,53 @@
+{% extends "templates/content.html" %}
+
+{%- from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs -%}
+{%- from "templates/components/alert.html" import alert -%}
+{%- from "templates/components/meta_tags.html" import metaTags -%}
+
+{% set pageTitle = "Past alerts" %}
+
+{% block metaTags %}
+  {{ metaTags(
+    description="Emergency alerts that were previously sent",
+    title=pageTitle,
+    url="https://www.gov.uk/alerts/past-alerts"
+  ) }}
+{% endblock %}
+
+{% block prefetch %}
+  <link rel="prefetch" href="{{ '/alerts/assets/javascripts/govuk-frontend-details-and-button.js' | file_fingerprint }}" />
+{% endblock %}
+
+{% block pageTitleCurrent -%}
+  {{ pageTitle }}
+{%- endblock %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Home",
+        "href": "/"
+      },
+      {
+        "text": "Emergency alerts",
+        "href": "/alerts"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">
+    {{ pageTitle }}
+  </h1>
+  {% for previous_alert in alerts.expired %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  {{ alert(alert=previous_alert) }}
+  {% endfor %}
+  {% if alerts.expired %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">
+  {% else %}
+  <p class="govuk-body">There are no previous alerts.</p>
+  {% endif %}
+{% endblock %}

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -47,6 +47,14 @@
         'columns': 2,
         'items': [
           {
+            'text': 'Current alerts',
+            'href': '/alerts/current-alerts'
+          },
+          {
+            'text': 'Past alerts',
+            'href': '/alerts/past-alerts'
+          },
+          {
             'text': 'When you get an emergency alert',
             'href': '/alerts/when-you-get-an-alert'
           },

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -4,7 +4,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="alerts-icon__container alerts-icon__container--48">
-        {{ alerts_icon(height=48) }}
+        {{ alerts_icon(height=48, alert_active=alert.is_current) }}
         <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-1">
           <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.area_names | formatted_list(before_each='', after_each='') }}
         </h2>

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -1,19 +1,19 @@
 {%- from "templates/components/alerts_icon.html" import alerts_icon -%}
 
-{% macro alert(areas, message, identifier) %}
+{% macro alert(alert) %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="alerts-icon__container alerts-icon__container--48">
         {{ alerts_icon(height=48) }}
         <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-1">
-          <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ areas | formatted_list(before_each='', after_each='') }}
+          <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.area_names | formatted_list(before_each='', after_each='') }}
         </h2>
         <p class="alerts-alert__message govuk-body-l govuk-!-margin-bottom-4">
-          {{ message }}
+          {{ alert.description }}
         </p>
-        <a href="/alerts/{{ identifier }}" class="govuk-link govuk-body">
-          More information about this alert 
-          <span class="govuk-visually-hidden">to {{ areas | formatted_list(before_each='', after_each='') }}</span>
+        <a href="/alerts/{{ alert.identifier }}" class="govuk-link govuk-body">
+          More information about this alert
+          <span class="govuk-visually-hidden">to {{ alert.area_names | formatted_list(before_each='', after_each='') }}</span>
         </a>
       </div>
     </div>

--- a/templates/components/alerts_icon.html
+++ b/templates/components/alerts_icon.html
@@ -1,4 +1,12 @@
-{% macro alerts_icon(height, x=0, y=0, degrade=True, fill="#de1924", fallback="alert.png") %}
+{% macro alerts_icon(height, x=0, y=0, degrade=True, alert_active=True) %}
+  {% if alert_active %}
+    {% set fill = "#de1924" %}
+    {% set fallback = "alert.png" %}
+  {% else %}
+    {% set fill = "#b1b4b6" %}
+    {% set fallback = "alert-grey.png" %}
+  {% endif %}
+
   {% set width = (height / 100 * 106)|round(0, 'floor') %}
   {% if degrade %}
     <!--[if gt IE 8]><!-->

--- a/templates/components/banner.html
+++ b/templates/components/banner.html
@@ -15,7 +15,7 @@
 
 {% macro planned_tests_banner(number_of_alerts, subtitle) %}
   <div class="alerts-notification-banner alerts-icon__container alerts-icon__container--48" role="region" aria-labelledby="alerts-notification-banner__title">
-    {{ alerts_icon(height=48, fill="#b1b4b6", fallback="alert-grey.png") }}
+    {{ alerts_icon(height=48, alert_active=False) }}
     <h2 class="alerts-notification-banner__title govuk-heading-m govuk-!-margin-bottom-1" id="alerts-notification-banner__title">
       <a class="govuk-link govuk-link--no-visited-state" href="/alerts/planned-tests">{{ number_of_alerts }} planned {% if number_of_alerts == 1 %}test{% else %}tests{% endif %}</a>
     </h2>

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -14,6 +14,22 @@ def test_alert_sent_and_expiry_properties_are_AlertDates(alert_dict):
     assert isinstance(alert.expires_date, AlertDate)
 
 
+@pytest.mark.parametrize('expiry_date,is_current', [
+    [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), True],
+    [datetime(2021, 4, 21, 11, 0, tzinfo=pytz.utc), False],
+])
+@freeze_time(datetime(
+    2021, 4, 21, 10, 30, tzinfo=pytz.utc
+))
+def test_is_expired_alert_checks_if_alert_is_expired(
+    expiry_date,
+    is_current,
+    alert_dict
+):
+    alert_dict['expires'] = expiry_date
+    assert Alert(alert_dict).is_expired == is_current
+
+
 @pytest.mark.parametrize('sent_date,expiry_date,is_current', [
     [
         datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc),

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -14,13 +14,32 @@ def test_alert_sent_and_expiry_properties_are_AlertDates(alert_dict):
     assert isinstance(alert.expires_date, AlertDate)
 
 
-@pytest.mark.parametrize('expiry_date,is_current', [
-    [datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc), True],
-    [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), False],
+@pytest.mark.parametrize('sent_date,expiry_date,is_current', [
+    [
+        datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc),
+        datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc),
+        True
+    ],
+    [
+        datetime(2021, 4, 21, 11, 0, tzinfo=pytz.utc),
+        datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc),
+        False
+    ],
+    [
+        datetime(2021, 4, 21, 9, 0, tzinfo=pytz.utc),
+        datetime(2021, 4, 21, 10, 0, tzinfo=pytz.utc),
+        False
+    ],
 ])
 @freeze_time(datetime(
     2021, 4, 21, 10, 30, tzinfo=pytz.utc
 ))
-def test_is_current_alert_checks_if_alert_is_current(expiry_date, is_current, alert_dict):
+def test_is_current_alert_checks_if_alert_is_current(
+    sent_date,
+    expiry_date,
+    is_current,
+    alert_dict
+):
+    alert_dict['sent'] = sent_date
     alert_dict['expires'] = expiry_date
     assert Alert(alert_dict).is_current == is_current

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -25,14 +25,28 @@ def test_from_yaml_loads_data(tmp_path, alert_dict):
     assert isinstance(alerts.last_updated_date, AlertDate)
 
 
-@pytest.mark.parametrize('expiry_date,expected_len', [
-    [datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc), 1],
-    [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), 0],
+@pytest.mark.parametrize('sent_date,expiry_date,expected_len', [
+    [
+        datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc),
+        datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc),
+        1
+    ],
+    [
+        datetime(2021, 4, 21, 11, 0, tzinfo=pytz.utc),
+        datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc),
+        0
+    ],
+    [
+        datetime(2021, 4, 21, 9, 0, tzinfo=pytz.utc),
+        datetime(2021, 4, 21, 10, 0, tzinfo=pytz.utc),
+        0
+    ],
 ])
 @freeze_time(datetime(
     2021, 4, 21, 10, 30, tzinfo=pytz.utc
 ))
-def test_current_alerts_are_current(expiry_date, expected_len, alert_dict):
+def test_current_alerts_are_current(sent_date, expiry_date, expected_len, alert_dict):
+    alert_dict['sent'] = sent_date
     alert_dict['expires'] = expiry_date
 
     alerts = Alerts({

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -25,6 +25,24 @@ def test_from_yaml_loads_data(tmp_path, alert_dict):
     assert isinstance(alerts.last_updated_date, AlertDate)
 
 
+@pytest.mark.parametrize('expiry_date,expected_len', [
+    [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), 1],
+    [datetime(2021, 4, 21, 11, 0, tzinfo=pytz.utc), 0],
+])
+@freeze_time(datetime(
+    2021, 4, 21, 10, 30, tzinfo=pytz.utc
+))
+def test_expired_alerts_are_expired(expiry_date, expected_len, alert_dict):
+    alert_dict['expires'] = expiry_date
+
+    alerts = Alerts({
+        'last_updated': datetime(2020, 1, 1, 10, 00),
+        'alerts': [alert_dict]
+    })
+
+    assert len(alerts.expired) == expected_len
+
+
 @pytest.mark.parametrize('sent_date,expiry_date,expected_len', [
     [
         datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc),


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178198202

I've tried to limit the number of decisions in this PR. Once
this is merged, it should then be a safe and simpler task to
iterate the design, noting that the page won't have content
until the first alert expires.

Things to (ideally) do in future work:

- Rebase https://github.com/alphagov/notifications-govuk-alerts/pull/65 to support "paragraphize" on the previous alerts page.
- Decide if we want to show author/timing info in the list of previous/current alerts
- Decide if we want to modify the single alert page to clearly show it's expired (we probably want to do more than change the colour of the icon, so I've just left it untouched in this PR)

## Screenshots (pages)

| New page  | Expired alert page (breadcrumb) |
| ------------- | ------------- |
| <img width="676" alt="Screenshot 2021-05-21 at 17 50 31" src="https://user-images.githubusercontent.com/9029009/119171908-21662800-ba5d-11eb-9cd4-39662805af55.png"> | <img width="749" alt="Screenshot 2021-05-24 at 10 34 22" src="https://user-images.githubusercontent.com/9029009/119328230-c9f1d300-bc7b-11eb-9d06-eb5f07f95661.png">
 |

## Screenshot (footer)

<img width="1042" alt="Screenshot 2021-05-24 at 10 35 21" src="https://user-images.githubusercontent.com/9029009/119328255-d0804a80-bc7b-11eb-8e22-ae51f843c735.png">



