### PR TITLE
Add content of test alert to planned alerts page

### DIFF
--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -53,6 +53,20 @@
       <p class="govuk-body">
         You may get up to 2 alerts.
       </p>
+      <p class="govuk-body">
+        The alert will say:
+      </p>
+      <div class="govuk-inset-text govuk-!-margin-top-2">
+        <p class="govuk-body">
+          The UK government is testing Emergency Alerts in East Suffolk.
+        </p>
+        <p class="govuk-body">
+          Emergency alerts tell you what to do if there’s a life-threatening event nearby.
+        </p>
+        <p class="govuk-body">
+          To find out more, call 0808 1697692 or search for gov.uk/alerts
+        </p>
+      </div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
We’ve been asked to add this by the comms agency to help with partner outreach.

![image](https://user-images.githubusercontent.com/355079/119320972-0de0da00-bc74-11eb-9a17-468b419031db.png)

