### PR TITLE
Add details of planned test in Reading

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -42,9 +42,6 @@
   {% if alerts.current %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ banner(alerts.current | length, alerts.last_updated_date) }}
-  {% else %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ planned_tests_banner(1, "Tuesday 25 May") }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -39,31 +39,17 @@
         {{ pageTitle }}
       </h1>
       <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-        Tuesday 25 May 2021
+        Tuesday 15 June 2021
       </h2>
       <h3 class="govuk-body govuk-!-margin-bottom-6">
-        East Suffolk
+        Reading
       </h3>
       <p class="govuk-body">
-        The UK government will send 2 test alerts between 1pm and 2pm.
+        The UK government will send a test alert.
       </p>
       <p class="govuk-body">
         If you get an alert, your phone or tablet may make a loud siren-like sound. You do not need to take any action.
       </p>
-      <p class="govuk-body">
-        The alerts will say:
-      </p>
-      <div class="govuk-inset-text govuk-!-margin-top-2">
-        <p class="govuk-body">
-          The UK government is testing Emergency Alerts in East Suffolk.
-        </p>
-        <p class="govuk-body">
-          Emergency alerts tell you what to do if there’s a life-threatening event nearby.
-        </p>
-        <p class="govuk-body">
-          To find out more, call 0808 1697692 or search for gov.uk/alerts
-        </p>
-      </div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
_Should not be merged until after 1pm on Tuesday 25 May._

***

So that this page doesn’t become outdated this commit replaces details of the East Suffolk test (which will be on the previous alerts page) with details of the upcoming test in Reading.

The date of this test has been given to the media<sup>1</sup>, so it’s OK for us to give the date publicly. We can add more detail closer to the day.

---

1. https://www.bbc.co.uk/news/uk-politics-57145675