### PR TITLE
Remove references to iPads

### DIFF
--- a/src/how-alerts-work.html
+++ b/src/how-alerts-work.html
@@ -75,7 +75,7 @@
         Emergency alerts work on:
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>iPhones and iPads running iOS 14.5 or later</li>
+        <li>iPhones running iOS 14.5 or later</li>
         <li>Android phones and tablets running Android 11 or later</li>
       </ul>
       <p class="govuk-body">

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -7,7 +7,7 @@
 
 {% block metaTags %}
   {{ metaTags(
-    description="How to turn off emergency alerts on Android phones and tablets, iPhones and iPads",
+    description="How to turn off emergency alerts on Android phones and tablets, and iPhones",
     title=pageTitle,
     url="https://www.gov.uk/alerts/opt-out"
   ) }}
@@ -57,7 +57,7 @@
         If this does not work, contact your device manufacturer.
       </p>
       <h2 class="govuk-heading-m">
-        iPhone and iPad
+        iPhone
       </h2>
       <p class="govuk-body">
         To opt out, search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Severe alerts</b>.

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -80,7 +80,7 @@
         "classes": "govuk-!-margin-bottom-3"
       }) }}
       {% set iosButton %}
-        <span class="govuk-visually-hidden">Find alerts on </span>iPhone and iPad
+        <span class="govuk-visually-hidden">Find alerts on </span>iPhone
       {% endset %}
       {% set iosAdvice %}
         <p class="govuk-body">


### PR DESCRIPTION
We’ve been informed that emergency alerts aren’t compatible with iPads.