### PR TITLE
Fix double nested paragraph

### DIFF
--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -5,12 +5,10 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="alerts-icon__container alerts-icon__container--48">
         {{ alerts_icon(height=48, alert_active=alert.is_current) }}
-        <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-1">
+        <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
           <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.area_names | formatted_list(before_each='', after_each='') }}
         </h2>
-        <p class="alerts-alert__message govuk-body-l govuk-!-margin-bottom-4">
-          {{ alert.description | paragraphize }}
-        </p>
+        {{ alert.description | paragraphize }}
         <a href="/alerts/{{ alert.identifier }}" class="govuk-link govuk-body">
           More information about this alert
           <span class="govuk-visually-hidden">to {{ alert.area_names | formatted_list(before_each='', after_each='') }}</span>


### PR DESCRIPTION
Paragraphs inside paragraphs aren’t valid HTML. They also introduce extra spacing.

This commit removes the containing paragraph (`paragraphize` will always give us at least one paragraph) and adjust the spacing to suit.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/119352425-958d0f80-bc99-11eb-89b2-4483f2aca757.png) | ![image](https://user-images.githubusercontent.com/355079/119352355-7bebc800-bc99-11eb-94c9-893cdeb4bad8.png)
