### PR TITLE
Make spacing between double details tighter

### DIFF
--- a/src/alert.html
+++ b/src/alert.html
@@ -70,7 +70,8 @@
   {% endset %}
   {{ govukDetails({
     "summaryText": "See where this alert was sent",
-    "html": alertAreas
+    "html": alertAreas,
+    "classes": "govuk-!-margin-bottom-3"
   }) }}
   {% set sharingContent %}
     <div class="share-url">


### PR DESCRIPTION
Replicates the work done in https://github.com/alphagov/notifications-govuk-alerts/pull/44