### PR TITLE
Set the last updated automatically

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -1,4 +1,3 @@
-last_updated: 2021-05-25T13:00:00+01:00
 alerts:
   - identifier: 3-may-2021
     message_type: alert

--- a/lib/alerts.py
+++ b/lib/alerts.py
@@ -8,10 +8,6 @@ from lib.alert_date import AlertDate
 class Alerts(SerialisedModelCollection):
     model = Alert
 
-    def __init__(self, data):
-        self.last_updated = data['last_updated']
-        super().__init__(data['alerts'])
-
     @property
     def current(self):
         return [alert for alert in self if alert.is_current]
@@ -19,6 +15,10 @@ class Alerts(SerialisedModelCollection):
     @property
     def expired(self):
         return [alert for alert in self if alert.is_expired]
+
+    @property
+    def last_updated(self):
+        return max(alert.starts for alert in self if alert.is_current)
 
     @property
     def last_updated_date(self):
@@ -29,4 +29,4 @@ class Alerts(SerialisedModelCollection):
         with path.open() as stream:
             data = yaml.load(stream, Loader=yaml.CLoader)
 
-        return cls(data)
+        return cls(data['alerts'])

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -31,24 +31,19 @@ def test_from_yaml_loads_data(tmp_path, alert_dict):
     2021, 4, 21, 11, 30, tzinfo=pytz.utc
 ))
 def test_last_updated(alert_dict):
-    alert_dict_1 = alert_dict.copy()
-    alert_dict_1['starts'] = datetime(
+    alert_dict['starts'] = datetime(
         2021, 4, 21, 11, 10, tzinfo=pytz.utc
     )
     alert_dict_2 = alert_dict.copy()
     alert_dict_2['starts'] = datetime(
         2021, 4, 21, 11, 20, tzinfo=pytz.utc
     )
-    alert_dict_3 = alert_dict.copy()
-    alert_dict_3['starts'] = datetime(
-        2021, 4, 21, 11, 30, tzinfo=pytz.utc
-    )
 
-    alerts = Alerts([alert_dict_1, alert_dict_2, alert_dict_3])
+    alerts = Alerts([alert_dict, alert_dict_2])
 
-    assert len(alerts) == 3
+    assert len(alerts) == len(alerts.current) == 2
     assert isinstance(alerts.last_updated_date, AlertDate)
-    assert alerts.last_updated == alert_dict_3['starts']
+    assert alerts.last_updated == alert_dict_2['starts']
 
 
 def test_last_updated_exception_for_no_current_alerts(alert_dict):

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -51,6 +51,11 @@ def test_last_updated(alert_dict):
     assert alerts.last_updated == alert_dict_3['starts']
 
 
+def test_last_updated_exception_for_no_current_alerts(alert_dict):
+    with pytest.raises(ValueError):
+        Alerts([alert_dict]).last_updated
+
+
 @pytest.mark.parametrize('expiry_date,expected_len', [
     [datetime(2021, 4, 21, 9, 30, tzinfo=pytz.utc), 1],
     [datetime(2021, 4, 21, 11, 0, tzinfo=pytz.utc), 0],


### PR DESCRIPTION
The most recent time the site will be updated with new information is when the most recent alert was broadcast.

This commit sets that date automatically, so we don’t have to update it manually (something we might forget to do).