### PR TITLE
Update what happens when you get an emergency alert

### DIFF
--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -42,7 +42,7 @@
       <p class="govuk-body">
         Your phone or tablet may: 
       </p>
-      <ul class="govuk-list govuk-bullet-list">
+      <ul class="govuk-list govuk-list--bullet">
         <li>
            make a loud siren-like sound, even if it’s set on silent
         </li>

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -40,10 +40,21 @@
         When you get an emergency alert
       </h1>
       <p class="govuk-body">
-        Your phone or tablet will vibrate and make a loud siren-like sound, even if it’s set on silent.
+        Your phone or tablet may: 
       </p>
+      <ul class="govuk-list govuk-bullet-list">
+        <li>
+           make a loud siren-like sound, even if it’s set on silent
+        </li>
+        <li>
+          vibrate
+        </li>
+        <li>
+          read out the alert
+        </li>
+      </ul>
       <p class="govuk-body">
-        Follow the instructions in the alert.
+        Stop what you’re doing and follow the instructions in the alert.
       </p>
       <p class="govuk-body">
         Sometimes an alert will include a phone number or a link to the GOV.UK website for more information.
@@ -55,7 +66,7 @@
         If you’re driving when you get an alert
       </h2>
       <p class="govuk-body">
-        Find somewhere safe to stop before using your phone. It is illegal to use a hand-held device while driving.
+        Find somewhere safe to stop before using your phone or tablet. It is illegal to use a hand-held device while driving.
       </p>
       <h2 class="govuk-heading-m">
         If you want to see an alert again


### PR DESCRIPTION
This PR updates the list of things that can happen when you get an emergency alert.

In previous trials, a higher proportion of devices than expected read the alert aloud. We should make users aware of this.

We’ve also changed ‘will’ to ‘may’, because not all devices behave the same way when they get an alert.