### PR TITLE
Say ‘UK government’ sent the alert

### DIFF
--- a/src/alert.html
+++ b/src/alert.html
@@ -54,7 +54,7 @@
       {{ alert_data.description | paragraphize }}
 
       <p class="govuk-body govuk-!-margin-bottom-0">
-        Issued by Cabinet Office <span class="relative-date__prefix">on </span><time class="relative-date" datetime="{{ alert_data.starts_date.as_iso8601 }}">{{ alert_data.starts_date.as_lang }}</time>
+        Issued by the UK government <span class="relative-date__prefix">on </span><time class="relative-date" datetime="{{ alert_data.starts_date.as_iso8601 }}">{{ alert_data.starts_date.as_lang }}</time>
       </p>
     </div>
   </div>

--- a/src/alert.html
+++ b/src/alert.html
@@ -54,7 +54,7 @@
       {{ alert_data.description | paragraphize }}
 
       <p class="govuk-body govuk-!-margin-bottom-0">
-        Issued by the UK government <span class="relative-date__prefix">on </span><time class="relative-date" datetime="{{ alert_data.starts_date.as_iso8601 }}">{{ alert_data.starts_date.as_lang }}</time>
+        Sent by the UK government <span class="relative-date__prefix">on </span><time class="relative-date" datetime="{{ alert_data.starts_date.as_iso8601 }}">{{ alert_data.starts_date.as_lang }}</time>
       </p>
     </div>
   </div>


### PR DESCRIPTION
This is consistent with who we are saying sent the alert in comms

> **government**
> Lower case unless it’s a full title. For example: ‘UK government’, but ‘Her Majesty’s Government of the United Kingdom of Great Britain and Northern Ireland’.

— https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#government