### PR TITLE
Remove accidentally committed CSS

### DIFF
--- a/src/assets/stylesheets/components/survey.scss
+++ b/src/assets/stylesheets/components/survey.scss
@@ -33,9 +33,6 @@
 }
 
 .alerts-feedback__prompt-question > .govuk-link {
-
-  //white-space: nowrap;
-
   &,
   &:active {
     color: govuk-colour("white");


### PR DESCRIPTION
We don’t need this because we’re using a non-breaking space in the HTML to control wrapping instead.