### PR TITLE
Format dates and times in GOV.UK style

### DIFF
--- a/lib/alert_date.py
+++ b/lib/alert_date.py
@@ -10,10 +10,19 @@ class AlertDate(object):
         self._local_datetime = _datetime.astimezone(timezone('Europe/London'))
 
     @property
+    def time_as_lang(self):
+        return {
+            '12:00AM': 'Midnight',
+            '12:00PM': 'Midday'
+        }.get(
+            f'{self._local_datetime:%-I:%M%p}',
+            f'{self._local_datetime:%-I:%M%p}',
+        ).lower()
+
+    @property
     def as_lang(self, lang='en-GB'):
         dt = self._local_datetime
-        am_pm = f'{dt:%p}'.lower()
-        return f'at {dt:%-I}:{dt:%M}{am_pm} on {dt.day} {dt:%B} {dt:%Y}'
+        return f'at {self.time_as_lang} on {dt.day} {dt:%B} {dt:%Y}'
 
     @property
     def as_iso8601(self):

--- a/lib/alert_date.py
+++ b/lib/alert_date.py
@@ -22,7 +22,7 @@ class AlertDate(object):
     @property
     def as_lang(self, lang='en-GB'):
         dt = self._local_datetime
-        return f'at {self.time_as_lang} on {dt.day} {dt:%B} {dt:%Y}'
+        return f'at {self.time_as_lang} on {dt:%A} {dt.day} {dt:%B} {dt:%Y}'
 
     @property
     def as_iso8601(self):

--- a/lib/alert_date.py
+++ b/lib/alert_date.py
@@ -11,7 +11,9 @@ class AlertDate(object):
 
     @property
     def as_lang(self, lang='en-GB'):
-        return '{dt.day} {dt:%B} {dt:%Y} at {dt:%H}:{dt:%M}'.format(dt=self._local_datetime)
+        dt = self._local_datetime
+        am_pm = f'{dt:%p}'.lower()
+        return f'at {dt:%-I}:{dt:%M}{am_pm} on {dt.day} {dt:%B} {dt:%Y}'
 
     @property
     def as_iso8601(self):

--- a/src/alert.html
+++ b/src/alert.html
@@ -54,7 +54,7 @@
       {{ alert_data.description | paragraphize }}
 
       <p class="govuk-body govuk-!-margin-bottom-0">
-        Sent by the UK government <span class="relative-date__prefix">at </span><time class="relative-date" datetime="{{ alert_data.starts_date.as_iso8601 }}">{{ alert_data.starts_date.as_lang }}</time>
+        Sent by the UK government <time datetime="{{ alert_data.starts_date.as_iso8601 }}">{{ alert_data.starts_date.as_lang }}</time>
       </p>
     </div>
   </div>

--- a/src/alert.html
+++ b/src/alert.html
@@ -54,7 +54,7 @@
       {{ alert_data.description | paragraphize }}
 
       <p class="govuk-body govuk-!-margin-bottom-0">
-        Sent by the UK government <span class="relative-date__prefix">on </span><time class="relative-date" datetime="{{ alert_data.starts_date.as_iso8601 }}">{{ alert_data.starts_date.as_lang }}</time>
+        Sent by the UK government <span class="relative-date__prefix">at </span><time class="relative-date" datetime="{{ alert_data.starts_date.as_iso8601 }}">{{ alert_data.starts_date.as_lang }}</time>
       </p>
     </div>
   </div>

--- a/tests/test_alert_date.py
+++ b/tests/test_alert_date.py
@@ -9,7 +9,7 @@ from lib.alert_date import AlertDate
 def test_AlertDate_properties():
     sample_datetime = datetime(2021, 3, 21, 10, 30, tzinfo=pytz.utc)
     alerts_date = AlertDate(sample_datetime)
-    assert alerts_date.as_lang == '21 March 2021 at 10:30'
+    assert alerts_date.as_lang == 'at 10:30am on 21 March 2021'
     assert alerts_date.as_iso8601 == '2021-03-21T10:30:00+00:00'
     assert alerts_date.as_utc_datetime == sample_datetime
     assert alerts_date.as_local_datetime == sample_datetime
@@ -19,7 +19,7 @@ def test_AlertDate_properties_work_with_bst():
     sample_datetime = datetime(2021, 4, 21, 10, 30, tzinfo=pytz.utc)
     datetime_in_bst = sample_datetime.astimezone(timezone('Europe/London'))
     alerts_date = AlertDate(datetime_in_bst)
-    assert alerts_date.as_lang == '21 April 2021 at 11:30'
+    assert alerts_date.as_lang == 'at 11:30am on 21 April 2021'
     assert alerts_date.as_iso8601 == '2021-04-21T11:30:00+01:00'
     assert alerts_date.as_utc_datetime == sample_datetime
     assert alerts_date.as_local_datetime == datetime_in_bst

--- a/tests/test_alert_date.py
+++ b/tests/test_alert_date.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 import pytz
 from pytz import timezone
 
@@ -23,3 +24,14 @@ def test_AlertDate_properties_work_with_bst():
     assert alerts_date.as_iso8601 == '2021-04-21T11:30:00+01:00'
     assert alerts_date.as_utc_datetime == sample_datetime
     assert alerts_date.as_local_datetime == datetime_in_bst
+
+
+@pytest.mark.parametrize('hour, minute, expected_lang', (
+    (0, 0, 'at midnight on 21 March 2021'),
+    (12, 0, 'at midday on 21 March 2021'),
+    (23, 59, 'at 11:59pm on 21 March 2021'),  # 12 hour clock
+))
+def test_AlertDate_at_midday_and_midnight(hour, minute, expected_lang):
+    sample_datetime = datetime(2021, 3, 21, hour, minute, tzinfo=pytz.utc)
+    alerts_date = AlertDate(sample_datetime)
+    assert alerts_date.as_lang == expected_lang

--- a/tests/test_alert_date.py
+++ b/tests/test_alert_date.py
@@ -10,7 +10,7 @@ from lib.alert_date import AlertDate
 def test_AlertDate_properties():
     sample_datetime = datetime(2021, 3, 21, 10, 30, tzinfo=pytz.utc)
     alerts_date = AlertDate(sample_datetime)
-    assert alerts_date.as_lang == 'at 10:30am on 21 March 2021'
+    assert alerts_date.as_lang == 'at 10:30am on Sunday 21 March 2021'
     assert alerts_date.as_iso8601 == '2021-03-21T10:30:00+00:00'
     assert alerts_date.as_utc_datetime == sample_datetime
     assert alerts_date.as_local_datetime == sample_datetime
@@ -20,16 +20,16 @@ def test_AlertDate_properties_work_with_bst():
     sample_datetime = datetime(2021, 4, 21, 10, 30, tzinfo=pytz.utc)
     datetime_in_bst = sample_datetime.astimezone(timezone('Europe/London'))
     alerts_date = AlertDate(datetime_in_bst)
-    assert alerts_date.as_lang == 'at 11:30am on 21 April 2021'
+    assert alerts_date.as_lang == 'at 11:30am on Wednesday 21 April 2021'
     assert alerts_date.as_iso8601 == '2021-04-21T11:30:00+01:00'
     assert alerts_date.as_utc_datetime == sample_datetime
     assert alerts_date.as_local_datetime == datetime_in_bst
 
 
 @pytest.mark.parametrize('hour, minute, expected_lang', (
-    (0, 0, 'at midnight on 21 March 2021'),
-    (12, 0, 'at midday on 21 March 2021'),
-    (23, 59, 'at 11:59pm on 21 March 2021'),  # 12 hour clock
+    (0, 0, 'at midnight on Sunday 21 March 2021'),
+    (12, 0, 'at midday on Sunday 21 March 2021'),
+    (23, 59, 'at 11:59pm on Sunday 21 March 2021'),  # 12 hour clock
 ))
 def test_AlertDate_at_midday_and_midnight(hour, minute, expected_lang):
     sample_datetime = datetime(2021, 3, 21, hour, minute, tzinfo=pytz.utc)


### PR DESCRIPTION
This pull request makes the way we show dates and times conform to the GOV.UK styleguide<sup>1</sup>. It also makes the date on the page for a single alert absolute, not relative.

# Before 

![image](https://user-images.githubusercontent.com/355079/119464186-667aaa80-bd3a-11eb-883a-58e1990fb721.png)

# After 

![image](https://user-images.githubusercontent.com/355079/119468617-87dd9580-bd3e-11eb-9b1c-d78ddff4986b.png)


***

1. https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times