### PR TITLE
Add expired date to past alerts

### DIFF
--- a/src/alert.html
+++ b/src/alert.html
@@ -51,6 +51,11 @@
   </h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds alert-icon__container">
+      {% if alert_data.is_expired %}
+      <h2 class="govuk-heading-s">
+        Stopped sending <time datetime="{{ alert_data.expires_date.as_iso8601 }}">{{ alert_data.expires_date.as_lang }}</time>
+      </h2>
+      {% endif %}
       {{ alert_data.description | paragraphize }}
 
       <p class="govuk-body govuk-!-margin-bottom-0">


### PR DESCRIPTION
The content on past alert pages needs to make clear that the alert is not about a current emergency.

All we can say for certain is that the alert has stopped sending. The emergency itself may be ongoing.

We agreed to prioritise the date and time over the body of the alert, reversing the order of priority of information on current alerts.

---

![image](https://user-images.githubusercontent.com/355079/119477092-929c2880-bd46-11eb-923d-d4451a5fc759.png)

---

Discussion: https://docs.google.com/document/d/1regPI_sAYQsHxUxgjQ3_nLiQ_E_qQkKiG4AIKATD0p8/edit#