### PR TITLE
Update headline of the test alert

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -4,7 +4,7 @@ alerts:
     sent: 2021-05-25T12:50:00+01:00
     starts: 2021-05-25T13:00:00+01:00
     expires: 2021-05-25T14:00:00+01:00
-    headline: Test Emergency Alert
+    headline: Emergency alert
     description: |
       The UK government is testing Emergency Alerts in East Suffolk.
 


### PR DESCRIPTION
This PR updates the headline field of the test alert to `Emergency alert`.

`Emergency alert` is closer to the user experience and consistent with the rest of the content on gov.uk/alerts.