### PR TITLE
Fix open graph image not showing due to relative path

### DIFF
--- a/templates/components/meta_tags.html
+++ b/templates/components/meta_tags.html
@@ -4,7 +4,7 @@
 <meta property="og:url" content="{{ url }}">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="GOV.UK">
-<meta property="og:image" content="{{ '/alerts/assets/images/opengraph-image.png' | file_fingerprint }}">
+<meta property="og:image" content="https://www.gov.uk{{ '/alerts/assets/images/opengraph-image.png' | file_fingerprint }}">
 <meta name="twitter:card" content="summary">
 <meta name="description" content="{{ description }}">
 {% endmacro %}


### PR DESCRIPTION
At the moment if you see gov.uk/alerts shared on twitter we do not have
an open graph image for it.

Example: https://twitter.com/ollietheantijab/status/1397235543423979524

I believe the problem is that our open graph url is relative rather than
absolute.

https://stackoverflow.com/questions/9858577/open-graph-can-resolve-relative-url

By changing it to an absolute URL I think this will fix it and it will
start appearing.