### PR TITLE
Remove relative-dates JS from alert page

### DIFF
--- a/src/alert.html
+++ b/src/alert.html
@@ -94,6 +94,5 @@
 {% block bodyEnd %}
   <script type="text/javascript" src="{{ '/alerts/assets/javascripts/govuk-frontend-details-and-button.js' | file_fingerprint }}"></script>
   <!--[if gt IE 8]><!--><script type="text/javascript" src="{{ '/alerts/assets/javascripts/sharing-button.js' | file_fingerprint }}"></script><!--<![endif]-->
-  <script async type="text/javascript" src="{{ '/alerts/assets/javascripts/relative-dates.js' | file_fingerprint }}"></script>
 
 {% endblock %}


### PR DESCRIPTION
It's no longer used, since the date it converted was converted to the full form, in https://github.com/alphagov/notifications-govuk-alerts/pull/88.