### PR TITLE
Add details of ongoing operator tests 

### DIFF
--- a/src/assets/stylesheets/_extensions.scss
+++ b/src/assets/stylesheets/_extensions.scss
@@ -4,5 +4,5 @@
 
 .extra-letter-spacing {
   @include govuk-font($size: false, $tabular: true);
-  letter-spacing: 0.06em;
+  letter-spacing: .06em;
 }

--- a/src/assets/stylesheets/_extensions.scss
+++ b/src/assets/stylesheets/_extensions.scss
@@ -1,3 +1,8 @@
 .govuk-footer {
   border-top: govuk-spacing(2) solid govuk-colour('blue');
 }
+
+.extra-letter-spacing {
+  @include govuk-font($size: false, $tabular: true);
+  letter-spacing: 0.06em;
+}

--- a/src/assets/stylesheets/_extensions.scss
+++ b/src/assets/stylesheets/_extensions.scss
@@ -2,7 +2,7 @@
   border-top: govuk-spacing(2) solid govuk-colour('blue');
 }
 
-.extra-letter-spacing {
+.govuk-\!-font-numeric {
   @include govuk-font($size: false, $tabular: true);
   letter-spacing: .06em;
 }

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -63,9 +63,6 @@
         Mobile network operators in the UK are <a href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
-      You may get an alert if you have an Android phone or tablet.
-      </p>
-      <p class="govuk-body">
         To opt out of these test alerts:
       </p>
       <ul class="govuk-list govuk-list--number">

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -56,7 +56,7 @@
       <p class="govuk-body">
         If this does not work, contact your device manufacturer.
       </p>
-      <h3 class="govuk-heading-s">
+      <h3 class="govuk-heading-s" id="mobile-network-tests">
         Opt out of mobile phone network tests
       </h3>
       <p class="govuk-body">

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -66,7 +66,7 @@
       You may get an alert if you have an Android phone or tablet.
       </p>
       <p class="govuk-body">
-        To opt out of these alerts:
+        To opt out of these test alerts:
       </p>
       <ul class="govuk-list govuk-list--number">
         <li>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -1,6 +1,7 @@
 {% extends "templates/content.html" %}
 
 {%- from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs -%}
+{%- from "govuk_frontend_jinja/components/details/macro.html" import govukDetails -%}
 {%- from "templates/components/meta_tags.html" import metaTags -%}
 
 {% set pageTitle = "How to opt out of emergency alerts" %}
@@ -65,23 +66,32 @@
       <p class="govuk-body">
         A small number of Android phones and tablets may receive these test alerts.
       </p>
-      <p class="govuk-body">
-        If you receive a test alert and want to opt out:
-      </p>
-      <ul class="govuk-list govuk-list--number">
-        <li>
-          Open your phone calling app.
-        </li>
-        <li>
-          Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>
-        </li>
-        <li>
-          Search your settings for ‘emergency alerts’.
-        </li>
-        <li>
-          Turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
-        </li>
-      </ul>
+      {% set testAlertButton %}
+        If you receive a mobile network operator test and want to opt out
+      {% endset %}
+      {% set testAlertAdvice %}
+        <p class="govuk-body">
+          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
+        </p>
+        <p class="govuk-body">
+          If you can’t see <b class="govuk-!-font-weight-bold">Test alerts</b>:
+        </p>
+        <ul class="govuk-list govuk-list--number">
+          <li>
+            Open your phone calling app.
+          </li>
+          <li>
+            Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>
+          </li>
+          <li>
+            Search your settings for ‘emergency alerts’ again
+          </li>
+        </ul>
+      {% endset %}
+      {{ govukDetails({
+        "summaryHtml": testAlertButton,
+        "html": testAlertAdvice
+      }) }}
       <h2 class="govuk-heading-m">
         iPhone
       </h2>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -58,7 +58,7 @@
       </p>
       <h3 class="govuk-heading-s">
         Opt out of mobile phone network tests
-      </h2>
+      </h3>
       <p class="govuk-body">
         Mobile network operators in the UK are <a href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -63,6 +63,9 @@
         Mobile network operators in the UK are <a href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
+      You may get an alert if you have an Android phone or tablet.
+      </p>
+      <p class="govuk-body">
         To opt out of these alerts:
       </p>
       <ul class="govuk-list govuk-list--number">

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -73,7 +73,9 @@
           Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>
         </li>
         <li>
-          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
+          Search your settings for ‘emergency alerts’.
+        </li>
+          Turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
         </li>
       </ul>
       <h2 class="govuk-heading-m">

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -57,7 +57,7 @@
         If this does not work, contact your device manufacturer.
       </p>
       <h3 class="govuk-heading-s" id="mobile-network-tests">
-        Opt out of mobile phone network tests
+        Mobile phone network tests
       </h3>
       <p class="govuk-body">
         Mobile network operators in the UK are <a href="/alerts/planned-tests">testing emergency alerts</a>.

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -63,7 +63,7 @@
         Mobile network operators in the UK are <a href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
-        To switch these alerts on or off:
+        To opt out of these alerts:
       </p>
       <ul class="govuk-list govuk-list--number">
         <li>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -73,7 +73,7 @@
           Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>
         </li>
         <li>
-          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>
+          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
         </li>
       </ul>
       <h2 class="govuk-heading-m">

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -63,7 +63,7 @@
         Mobile network operators in the UK are testing emergency alerts.
       </p>
       <p class="govuk-body">
-        To switch these alerts off or on:
+        To switch these alerts on or off:
       </p>
       <ul class="govuk-list govuk-list--number">
         <li>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -56,6 +56,26 @@
       <p class="govuk-body">
         If this does not work, contact your device manufacturer.
       </p>
+      <h2 class="govuk-heading-s">
+        Opt out of mobile phone network tests
+      </h2>
+      <p class="govuk-body">
+        Mobile network operators in the UK are testing emergency alerts.
+      </p>
+      <p class="govuk-body">
+        To switch these alerts off or on:
+      </p>
+      <ul class="govuk-list govuk-list--number">
+        <li>
+          Open your phone calling app
+        </li>
+        <li>
+          Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>
+        </li>
+        <li>
+          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>
+        </li>
+      </ul>
       <h2 class="govuk-heading-m">
         iPhone
       </h2>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -60,7 +60,7 @@
         Opt out of mobile phone network tests
       </h2>
       <p class="govuk-body">
-        Mobile network operators in the UK are testing emergency alerts.
+        Mobile network operators in the UK are <a href="#">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
         To switch these alerts on or off:

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -67,7 +67,7 @@
       </p>
       <ul class="govuk-list govuk-list--number">
         <li>
-          Open your phone calling app
+          Open your phone calling app.
         </li>
         <li>
           Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -56,7 +56,7 @@
       <p class="govuk-body">
         If this does not work, contact your device manufacturer.
       </p>
-      <h2 class="govuk-heading-s">
+      <h3 class="govuk-heading-s">
         Opt out of mobile phone network tests
       </h2>
       <p class="govuk-body">

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -78,6 +78,7 @@
         <li>
           Search your settings for ‘emergency alerts’.
         </li>
+        <li>
           Turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
         </li>
       </ul>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -63,7 +63,10 @@
         Mobile network operators in the UK are <a href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
-        To opt out of these test alerts on an Android phone or tablet:
+        A small number of Android phones and tablets may receive these test alerts.
+      </p>
+      <p class="govuk-body">
+        If you receive a test alert and want to opt out:
       </p>
       <ul class="govuk-list govuk-list--number">
         <li>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -60,7 +60,7 @@
         Opt out of mobile phone network tests
       </h2>
       <p class="govuk-body">
-        Mobile network operators in the UK are <a href="#">testing emergency alerts</a>.
+        Mobile network operators in the UK are <a href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
         To switch these alerts on or off:

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -63,7 +63,7 @@
         Mobile network operators in the UK are <a href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
-        To opt out of these test alerts:
+        To opt out of these test alerts on an Android phone or tablet:
       </p>
       <ul class="govuk-list govuk-list--number">
         <li>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -61,7 +61,7 @@
         Mobile phone networks in the UK are testing emergency alerts.
       </p>
       <p class="govuk-body">
-        You may get an alert if you have an Android phone or tablet.
+        You may get test alerts if you have an Android phone or tablet. If you get an alert, your device may make a loud siren-like sound.
       </p>
       <p class="govuk-body">
         The alerts will say:

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -51,7 +51,7 @@
         If you get an alert, your phone or tablet may make a loud siren-like sound. You do not need to take any action.
       </p>
 
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
         Ongoing
       </h2>
       <h3 class="govuk-body govuk-!-margin-bottom-6">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -75,7 +75,7 @@
         If you get an alert, your device may make a loud siren-like sound. You do not need to take any action.
       </p>
       <p class="govuk-body">
-        To switch these test alerts on or off:
+        To opt out of these test alerts:
       </p>
       <ul class="govuk-list govuk-list--number">
         <li>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -64,7 +64,7 @@
         You may get test alerts if you have an Android phone or tablet. If you get an alert, your device may make a loud siren-like sound.
       </p>
       <p class="govuk-body">
-        The test alerts will say:
+        The alerts will say:
       </p>
       <div class="govuk-inset-text govuk-!-margin-top-2">
         <p class="govuk-body">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -85,7 +85,7 @@
           Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>
         </li>
         <li>
-          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>
+          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
         </li>
     </div>
   </div>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -72,7 +72,7 @@
         </p>
       </div>
       <p class="govuk-body">
-        You can <a href="/alerts/opt-out#mobile-network-tests">opt out of mobile phone network tests</a>.
+        You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-tests">opt out of mobile phone network tests</a>.
       </p>
     </div>
   </div>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -50,6 +50,43 @@
       <p class="govuk-body">
         If you get an alert, your phone or tablet may make a loud siren-like sound. You do not need to take any action.
       </p>
+
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+        Ongoing
+      </h2>
+      <h3 class="govuk-body govuk-!-margin-bottom-6">
+        UK
+      </h3>
+      <p class="govuk-body">
+        Mobile phone networks in the UK are testing emergency alerts.
+      </p>
+      <p class="govuk-body">
+        You may get an alert if you have an Android phone or tablet.
+      </p>
+      <p class="govuk-body">
+        The alerts will say:
+      </p>
+      <div class="govuk-inset-text govuk-!-margin-top-2">
+        <p class="govuk-body">
+          This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
+        </p>
+      </div>
+      <p class="govuk-body">
+        If you get an alert, your device may make a loud siren-like sound. You do not need to take any action.
+      </p>
+      <p class="govuk-body">
+        To switch these test alerts on or off:
+      </p>
+      <ul class="govuk-list govuk-list--number">
+        <li>
+          Open your phone calling app
+        </li>
+        <li>
+          Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>
+        </li>
+        <li>
+          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>
+        </li>
     </div>
   </div>
 {% endblock %}

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -72,9 +72,6 @@
         </p>
       </div>
       <p class="govuk-body">
-        If you get an alert, your device may make a loud siren-like sound. You do not need to take any action.
-      </p>
-      <p class="govuk-body">
         To opt out of these test alerts:
       </p>
       <ul class="govuk-list govuk-list--number">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -72,7 +72,7 @@
         </p>
       </div>
       <p class="govuk-body">
-        You can <a href="/alerts/opt-out#mobile-network-tests">opt out of these test alerts</a>.
+        You can <a href="/alerts/opt-out#mobile-network-tests">opt out of mobile phone network tests</a>.
       </p>
     </div>
   </div>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -72,18 +72,8 @@
         </p>
       </div>
       <p class="govuk-body">
-        To opt out of these test alerts:
+        You can <a href="/alerts/opt-out#mobile-network-tests">opt out of these test alerts</a>.
       </p>
-      <ul class="govuk-list govuk-list--number">
-        <li>
-          Open your phone calling app.
-        </li>
-        <li>
-          Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>
-        </li>
-        <li>
-          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
-        </li>
     </div>
   </div>
 {% endblock %}

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -79,7 +79,7 @@
       </p>
       <ul class="govuk-list govuk-list--number">
         <li>
-          Open your phone calling app
+          Open your phone calling app.
         </li>
         <li>
           Use the keypad to enter <span class="extra-letter-spacing govuk-!-font-weight-bold">*#*#2627#*#*</span>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -64,7 +64,7 @@
         You may get test alerts if you have an Android phone or tablet. If you get an alert, your device may make a loud siren-like sound.
       </p>
       <p class="govuk-body">
-        The alerts will say:
+        The test alerts will say:
       </p>
       <div class="govuk-inset-text govuk-!-margin-top-2">
         <p class="govuk-body">

--- a/src/reasons-you-might-get-an-alert.html
+++ b/src/reasons-you-might-get-an-alert.html
@@ -39,7 +39,7 @@
         Reasons you might get an emergency alert
       </h1>
       <p class="govuk-body">
-        The government and mobile phone networks are testing emergency alerts.
+        The government and mobile phone networks are <a href="#">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
         If there’s a test in your local area, you might get an alert.

--- a/src/reasons-you-might-get-an-alert.html
+++ b/src/reasons-you-might-get-an-alert.html
@@ -39,7 +39,7 @@
         Reasons you might get an emergency alert
       </h1>
       <p class="govuk-body">
-        The government and mobile phone networks are <a href="#">testing emergency alerts</a>.
+        The government and mobile phone networks are <a href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
         If there’s a test in your local area, you might get an alert.

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -60,7 +60,7 @@
         Sometimes an alert will include a phone number or a link to the GOV.UK website for more information.
       </p>
       <div class="govuk-inset-text">
-        <p>The government and mobile phone networks are <a href="#">testing emergency alerts</a>. You may get an alert if you live in, or travel through, a test area.</p>
+        <p>The government and mobile phone networks are <a href="/alerts/planned-tests">testing emergency alerts</a>. You may get an alert if you live in, or travel through, a test area.</p>
       </div>
       <h2 class="govuk-heading-m">
         If you’re driving when you get an alert

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -60,7 +60,7 @@
         Sometimes an alert will include a phone number or a link to the GOV.UK website for more information.
       </p>
       <div class="govuk-inset-text">
-        <p>The government and mobile phone networks are testing emergency alerts. You may get an alert if you live in, or travel through, a test area.</p>
+        <p>The government and mobile phone networks are <a href="#">testing emergency alerts</a>. You may get an alert if you live in, or travel through, a test area.</p>
       </div>
       <h2 class="govuk-heading-m">
         If you’re driving when you get an alert

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -76,6 +76,10 @@
           {
             'text': 'Opt out of emergency alerts',
             'href': '/alerts/opt-out'
+          },
+          {
+            'text': 'Planned tests',
+            'href': '/alerts/planned-tests'
           }
         ]
       }


### PR DESCRIPTION
This PR adds:

- information about the ongoing operator tests to the _Planned tests_ page
- a link to _Planned tests_ from the footer
- links to _Planned tests_ from relevant content on other pages
- updated opt-out instructions for test messages on the _Opt out_ page
- a link from _Planned tests_ to the _Opt out_ page

