### PR TITLE
Add content for users who cannot receive alerts

### DIFF
--- a/src/how-alerts-work.html
+++ b/src/how-alerts-work.html
@@ -97,10 +97,10 @@
         If you cannot receive emergency alerts
       </h2>
       <p class="govuk-body">
-        Emergency alerts are not the only way to warn people when lives are in danger.
+        The emergency services have other ways to warn you when lives are in danger.
       </p>
       <p class="govuk-body">
-        The emergency services will still use existing ways of sharing information. For example, local news, television, radio or social media.
+        Emergency alerts will not replace local news, radio, television or social media.
       </p>
     </div>
   </div>

--- a/src/how-alerts-work.html
+++ b/src/how-alerts-work.html
@@ -93,7 +93,7 @@
       <p class="govuk-body">
         Emergency alerts do not cause, and are not affected by, busy phone networks.
       </p>
-      <h2 class="govuk-heading-m" id="mobile-phone-networks">
+      <h2 class="govuk-heading-m" id="cannot-get-alerts">
         If you cannot receive emergency alerts
       </h2>
       <p class="govuk-body">

--- a/src/how-alerts-work.html
+++ b/src/how-alerts-work.html
@@ -93,6 +93,15 @@
       <p class="govuk-body">
         Emergency alerts do not cause, and are not affected by, busy phone networks.
       </p>
+      <h2 class="govuk-heading-m" id="mobile-phone-networks">
+        If you cannot receive emergency alerts
+      </h2>
+      <p class="govuk-body">
+        Emergency alerts are not the only way to warn people when lives are in danger.
+      </p>
+      <p class="govuk-body">
+        The emergency services will still use existing ways of sharing information. For example, local news, television, radio or social media.
+      </p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This PR adds content for users who cannot receive emergency alerts – either because their device is not compatible, or they do not have a phone or tablet.