### PR TITLE
Put planned tests ahead of Reading test

### DIFF
--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -38,18 +38,6 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-        Tuesday 15 June 2021
-      </h2>
-      <h3 class="govuk-body govuk-!-margin-bottom-6">
-        Reading
-      </h3>
-      <p class="govuk-body">
-        The UK government will send a test alert.
-      </p>
-      <p class="govuk-body">
-        If you get an alert, your phone or tablet may make a loud siren-like sound. You do not need to take any action.
-      </p>
 
       <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
         Ongoing
@@ -73,6 +61,19 @@
       </div>
       <p class="govuk-body">
         You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-tests">opt out of mobile phone network tests</a>.
+      </p>
+
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+        Tuesday 15 June 2021
+      </h2>
+      <h3 class="govuk-body govuk-!-margin-bottom-6">
+        Reading
+      </h3>
+      <p class="govuk-body">
+        The UK government will send a test alert.
+      </p>
+      <p class="govuk-body">
+        If you get an alert, your phone or tablet may make a loud siren-like sound. You do not need to take any action.
       </p>
     </div>
   </div>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -43,7 +43,7 @@
         Ongoing
       </h2>
       <h3 class="govuk-body govuk-!-margin-bottom-6">
-        UK
+        Across the UK
       </h3>
       <p class="govuk-body">
         Mobile phone networks in the UK are testing emergency alerts.


### PR DESCRIPTION
Operator tests will be happening sooner than the Reading test, so we should lead with those.