### PR TITLE
Add content about current and past alerts

### DIFF
--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -72,7 +72,7 @@
         If you want to see an alert again
       </h2>
       <p class="govuk-body">
-        Visit gov.uk/alerts to see <a href="/alerts/current-alerts">current alerts</a> and <a href="/alerts/current-alerts">past alerts</a>.
+        You can find <a href="/alerts/current-alerts">current alerts</a> and <a href="/alerts/current-alerts">past alerts</a> at gov.uk/alerts.
       </p>
       <p class="govuk-body">
         You can also find them on your phone or tablet. 

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -75,7 +75,7 @@
         Visit gov.uk/alerts to see <a href="/alerts/current-alerts">current alerts</a> and <a href="/alerts/current-alerts">past alerts</a>.
       </p>
       <p class="govuk-body">
-        You can also find current and past alerts on your phone or tablet. 
+        You can also find them on your phone or tablet. 
       </p>
       {% set androidButton %}
         <span class="govuk-visually-hidden">Find alerts on </span>Android phones and tablets

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -72,7 +72,7 @@
         If you want to see an alert again
       </h2>
       <p class="govuk-body">
-        Visit gov.uk/alerts to see a list of <a href="/alerts/current-alerts">current alerts</a> and <a href="/alerts/current-alerts">past alerts</a>.
+        Visit gov.uk/alerts to see <a href="/alerts/current-alerts">current alerts</a> and <a href="/alerts/current-alerts">past alerts</a>.
       </p>
       <p class="govuk-body">
         You can also find current and past alerts on your phone or tablet. 

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -72,7 +72,10 @@
         If you want to see an alert again
       </h2>
       <p class="govuk-body">
-        You can find current and past alerts on your phone or tablet.
+        Visit gov.uk/alerts to see a list of <a href="/alerts/current-alerts">current alerts</a> and <a href="/alerts/current-alerts">past alerts</a>.
+      </p>
+      <p class="govuk-body">
+        You can also find current and past alerts on your phone or tablet. 
       </p>
       {% set androidButton %}
         <span class="govuk-visually-hidden">Find alerts on </span>Android phones and tablets

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -75,7 +75,7 @@
         You can find <a href="/alerts/current-alerts">current alerts</a> and <a href="/alerts/current-alerts">past alerts</a> at gov.uk/alerts.
       </p>
       <p class="govuk-body">
-        You can also find them on your phone or tablet. 
+        You can also search for them on your phone or tablet. 
       </p>
       {% set androidButton %}
         <span class="govuk-visually-hidden">Find alerts on </span>Android phones and tablets


### PR DESCRIPTION
The PR adds content about (and links to) current and past alerts on GOV.UK.

We removed this line when we launched the MVP site, but now the current and past alerts pages are live we can reinstate it.