### PR TITLE
Add JS tests for sharing button

### DIFF
--- a/src/assets/javascripts/sharing-button.mjs
+++ b/src/assets/javascripts/sharing-button.mjs
@@ -7,11 +7,14 @@ export default function sharingButton () {
   var urlString
   var onClick
 
+  // return early if no of the required APIs are available
+  if (!navigator.share && !document.queryCommandSupported('copy')) return
+
   btn.className = 'govuk-button govuk-button--secondary'
   btn.setAttribute('data-module', 'govuk-button')
   if (navigator.share) {
     btn.innerHTML = 'Share link'
-  } else {
+  } else if (document.queryCommandSupported('copy')) {
     btn.innerHTML = 'Copy link'
   }
 

--- a/src/assets/javascripts/sharing-button.mjs
+++ b/src/assets/javascripts/sharing-button.mjs
@@ -19,7 +19,8 @@ export default function sharingButton () {
   }
 
   if (navigator.share) {
-    urlString = url.innerHTML.replace(/^[\s]+$/, '')
+    // Regexp taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#polyfill
+    urlString = url.innerHTML.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '')
 
     onClick = function (evt) {
       try {

--- a/tests/javascripts/sharing-button.test.js
+++ b/tests/javascripts/sharing-button.test.js
@@ -1,0 +1,195 @@
+import helpers from './support/helpers.js'
+import sharingButton from '../../src/assets/javascripts/sharing-button.mjs'
+
+const URL = 'https://www.gov.uk/alerts/3-may-2021'
+const htmlFixture = `
+      <div class="share-url">
+        <p class="govuk-body">
+          ${URL}
+        </p>
+      </div>`
+
+afterAll(() => {
+  // clear up methods in the global space
+  document.queryCommandSupported = undefined
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+
+  jest.restoreAllMocks()
+})
+
+describe('If the Web Share API is supported', () => {
+
+  beforeEach(() => {
+
+    navigator.share = jest.fn(() => {})
+
+    // copy command would be supported if navigator.share is
+    document.queryCommandSupported = jest.fn(command => command === 'copy')
+
+    document.body.innerHTML = htmlFixture
+
+    sharingButton()
+
+  })
+
+  afterEach(() => {
+
+    delete navigator.share
+
+  })
+
+  describe('On page load', () => {
+
+    test('A button should be added below the URL to be shared', () => {
+
+      const URLParagraph = document.querySelector('.share-url > .govuk-body')
+
+      expect(URLParagraph.nextElementSibling).not.toBe(null)
+      expect(URLParagraph.nextElementSibling.classList.contains('govuk-button')).toBe(true)
+
+    })
+
+    test('The button should be for sharing the link', () => {
+
+      const button = document.querySelector('.share-url > .govuk-button')
+
+      expect(button.textContent.trim()).toEqual('Share link')
+
+    })
+
+  })
+
+  describe('If the button is clicked', () => {
+
+    test('The correct information should be sent to the Web Share API', () => {
+
+      const button = document.querySelector('.share-url > .govuk-button')
+      const clickEvent = new window.MouseEvent(
+        'click',
+        {
+          view: window,
+          bubbles: true,
+          cancelable: true
+        }
+      )
+
+      button.dispatchEvent(clickEvent)
+
+      expect(navigator.share).toHaveBeenCalledWith({
+        text: URL.replace(/^https:\/\//, ''),
+        url: URL
+      })
+
+    })
+
+  })
+
+})
+
+describe('If the Web Share API is not supported but the copy command is', () => {
+
+  let selectionMock
+  let rangeMock
+
+  beforeEach(() => {
+
+    // assume copy command is available
+    document.queryCommandSupported = jest.fn(command => command === 'copy')
+
+    // mock objects used to manipulate the page selection
+    selectionMock = new helpers.SelectionMock(jest)
+    rangeMock = new helpers.RangeMock(jest)
+
+    // plug gaps in JSDOM's API for manipulation of selections
+    window.getSelection = jest.fn(() => selectionMock)
+    document.createRange = jest.fn(() => rangeMock)
+
+    // plug JSDOM not having execCommand
+    document.execCommand = jest.fn(() => {})
+
+    document.body.innerHTML = htmlFixture
+    sharingButton()
+
+  })
+
+  afterEach(() => {
+
+    // reset mocked DOM APIs
+    window.getSelection = undefined
+    document.createRange = undefined
+    document.execCommand = undefined
+
+  })
+
+  describe('On page load', () => {
+
+    test('A button should be added below the URL to be shared', () => {
+
+      const URLParagraph = document.querySelector('.share-url > .govuk-body')
+
+      expect(URLParagraph.nextElementSibling).not.toBe(null)
+      expect(URLParagraph.nextElementSibling.classList.contains('govuk-button')).toBe(true)
+
+    })
+
+    test('The button should be for copying the link', () => {
+
+      const button = document.querySelector('.share-url > .govuk-button')
+
+      expect(button.textContent.trim()).toEqual('Copy link')
+
+    })
+
+  })
+
+  describe('If the button is clicked', () => {
+
+    test('The correct information should be added to the clipboard', () => {
+
+      const button = document.querySelector('.share-url > .govuk-button')
+      const urlParagraph = document.querySelector('.share-url > .govuk-body')
+      const clickEvent = new window.MouseEvent(
+        'click',
+        {
+          view: window,
+          bubbles: true,
+          cancelable: true
+        }
+      )
+
+      button.dispatchEvent(clickEvent)
+
+      // it should make a selection (a range) from the paragraph containing the URL
+      expect(rangeMock.selectNodeContents.mock.calls[0]).toEqual([urlParagraph])
+
+      // that selection (a range) should be added to that for the page (a selection)
+      expect(selectionMock.addRange.mock.calls[0]).toEqual([rangeMock])
+
+      expect(document.execCommand).toHaveBeenCalled()
+      expect(document.execCommand.mock.calls[0]).toEqual(['copy'])
+
+    })
+
+  })
+
+})
+
+describe('If neither the Web Share API or the copy command is supported', () => {
+
+  test('On page load, the button should not be added', () => {
+
+    document.body.innerHTML = htmlFixture
+
+    // fake support for the copy command not being available
+    document.queryCommandSupported = jest.fn(command => false)
+
+    sharingButton()
+
+    expect(document.querySelector('.share-url > .govuk-button')).toBe(null)
+
+  })
+
+})

--- a/tests/javascripts/sharing-button.test.js
+++ b/tests/javascripts/sharing-button.test.js
@@ -2,22 +2,27 @@ import helpers from './support/helpers.js'
 import sharingButton from '../../src/assets/javascripts/sharing-button.mjs'
 
 const URL = 'https://www.gov.uk/alerts/3-may-2021'
-const htmlFixture = `
-      <div class="share-url">
-        <p class="govuk-body">
-          ${URL}
-        </p>
-      </div>`
 
-afterAll(() => {
-  // clear up methods in the global space
-  document.queryCommandSupported = undefined
+beforeEach(() => {
+
+  document.body.innerHTML = `
+    <div class="share-url">
+      <p class="govuk-body">
+        ${URL}
+      </p>
+    </div>`
+
 })
 
 afterEach(() => {
+
+  // clear up methods in the global space
+  delete document.queryCommandSupported
+
   document.body.innerHTML = ''
 
   jest.restoreAllMocks()
+
 })
 
 describe('If the Web Share API is supported', () => {
@@ -28,8 +33,6 @@ describe('If the Web Share API is supported', () => {
 
     // copy command would be supported if navigator.share is
     document.queryCommandSupported = jest.fn(command => command === 'copy')
-
-    document.body.innerHTML = htmlFixture
 
     sharingButton()
 
@@ -45,10 +48,10 @@ describe('If the Web Share API is supported', () => {
 
     test('A button should be added below the URL to be shared', () => {
 
-      const URLParagraph = document.querySelector('.share-url > .govuk-body')
+      const urlParagraph = document.querySelector('.share-url > .govuk-body')
 
-      expect(URLParagraph.nextElementSibling).not.toBe(null)
-      expect(URLParagraph.nextElementSibling.classList.contains('govuk-button')).toBe(true)
+      expect(urlParagraph.nextElementSibling).not.toBe(null)
+      expect(urlParagraph.nextElementSibling.classList.contains('govuk-button')).toBe(true)
 
     })
 
@@ -110,7 +113,6 @@ describe('If the Web Share API is not supported but the copy command is', () => 
     // plug JSDOM not having execCommand
     document.execCommand = jest.fn(() => {})
 
-    document.body.innerHTML = htmlFixture
     sharingButton()
 
   })
@@ -128,10 +130,10 @@ describe('If the Web Share API is not supported but the copy command is', () => 
 
     test('A button should be added below the URL to be shared', () => {
 
-      const URLParagraph = document.querySelector('.share-url > .govuk-body')
+      const urlParagraph = document.querySelector('.share-url > .govuk-body')
 
-      expect(URLParagraph.nextElementSibling).not.toBe(null)
-      expect(URLParagraph.nextElementSibling.classList.contains('govuk-button')).toBe(true)
+      expect(urlParagraph.nextElementSibling).not.toBe(null)
+      expect(urlParagraph.nextElementSibling.classList.contains('govuk-button')).toBe(true)
 
     })
 
@@ -180,8 +182,6 @@ describe('If the Web Share API is not supported but the copy command is', () => 
 describe('If neither the Web Share API or the copy command is supported', () => {
 
   test('On page load, the button should not be added', () => {
-
-    document.body.innerHTML = htmlFixture
 
     // fake support for the copy command not being available
     document.queryCommandSupported = jest.fn(command => false)

--- a/tests/javascripts/support/helpers.js
+++ b/tests/javascripts/support/helpers.js
@@ -1,0 +1,49 @@
+// helpers for mocking DOM interfaces
+// see https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model#DOM_interfaces
+
+// Base class for mocking an DOM API interfaces not in JSDOM
+class DOMInterfaceMock {
+
+  constructor (jest, spec) {
+
+    // set up methods so their calls can be tracked
+    // leave implementation/return values to the test
+    spec.methods.forEach(method => this[method] = jest.fn(() => {}));
+
+    // set up props
+    // any spies should be relative to the test so not set here
+    spec.props.forEach(prop => {
+
+      Object.defineProperty(this, prop, {
+        get: () => this[prop],
+        set: value => this[prop] = value
+      });
+
+    });
+
+  }
+
+}
+
+// Very basic class for stubbing the Range interface
+// Only contains methods required for current tests
+class RangeMock extends DOMInterfaceMock {
+
+  constructor (jest) {
+    super(jest, { props: [], methods: ['selectNodeContents', 'setStart'] });
+  }
+
+}
+
+// Very basic class for stubbing the Selection interface
+// Only contains methods required for current tests
+class SelectionMock extends DOMInterfaceMock {
+
+  constructor (jest) {
+    super(jest, { props: [], methods: ['removeAllRanges', 'addRange'] });
+  }
+
+}
+
+exports.RangeMock = RangeMock;
+exports.SelectionMock = SelectionMock;

--- a/tests/javascripts/support/helpers.js
+++ b/tests/javascripts/support/helpers.js
@@ -30,7 +30,7 @@ class DOMInterfaceMock {
 class RangeMock extends DOMInterfaceMock {
 
   constructor (jest) {
-    super(jest, { props: [], methods: ['selectNodeContents', 'setStart'] });
+    super(jest, { props: [], methods: ['selectNodeContents'] });
   }
 
 }


### PR DESCRIPTION
Adds tests for the sharing button JS.

Part of https://www.pivotaltracker.com/story/show/177597156. This should complete the 'test the JavaScript works' task because we are not testing GOVUK Frontend code.

To run these tests only, use this command:

`npx jest --config tests/javascripts/jest.config.js tests/javascripts/sharing-button.test.js`

This pull request also includes:
- adding checks for copy-to-clipboard support instead of assuming it exists if the Web Share API doesn't
- updates the RegExp used to trim the URL string to use the `String.prototype.trim` polyfill from MDN