### PR TITLE
Fix fallback image for alert icon

### DIFF
--- a/templates/components/alerts_icon.html
+++ b/templates/components/alerts_icon.html
@@ -16,7 +16,7 @@
   {% if degrade %}
     <!--<![endif]-->
     <!--[if IE 8]>
-      <img src="/alerts/assets/images/{{ fallback }}" height="{{ height }}" width="{{ width }}", alt="{{ alt }}" class="example alerts-image__image--centred" />
+      <img src="/alerts/assets/images/{{ fallback }}" height="{{ height }}" width="{{ width }}", alt="{{ alt }}" class="alerts-icon alerts-icon--{{ height }}" />
     <![endif]-->
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
I noticed that the alert icon image, used as a fallback for the SVG version, is broken in IE8 (which uses it due to lack of support for SVG).

## Past alerts page

### Current

<img width="684" alt="past_alerts_current_ie8" src="https://user-images.githubusercontent.com/87140/121369315-a4c7ba80-c933-11eb-911b-032a4b1e918a.png">

### Fixed


<img width="674" alt="past_alerts_new_ie8" src="https://user-images.githubusercontent.com/87140/121371117-33890700-c935-11eb-968a-1dac33789305.png">

## Alert page

### Current

<img width="624" alt="alert_current_ie8" src="https://user-images.githubusercontent.com/87140/121369339-aabd9b80-c933-11eb-8616-3baba667a7e2.png">

### Fixed

<img width="686" alt="alert_new_ie8" src="https://user-images.githubusercontent.com/87140/121371091-2cfa8f80-c935-11eb-9af4-39ccd4ad9715.png">

Looks like the fallback image has classes intended for the example image on the home page (of the phone). This fixes it to instead have the same classes as the SVG it replaces.