### PR TITLE
Add test for inline script

### DIFF
--- a/tests/test_content_security_policy_sha.py
+++ b/tests/test_content_security_policy_sha.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 from tests.src import env
 
 
-def test_csp_sha():
+def test_content_security_policy_sha():
     script_sha256_base64_encoded = b"+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU="
     env.filters['file_fingerprint'] = lambda path: path  # stub out filters
 

--- a/tests/test_csp_sha.py
+++ b/tests/test_csp_sha.py
@@ -1,0 +1,27 @@
+import base64
+import hashlib
+
+from bs4 import BeautifulSoup
+
+from tests.src import env
+
+
+def test_csp_sha():
+    script_sha256_base64_encoded = b"+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU="
+    env.filters['file_fingerprint'] = lambda path: path  # stub out filters
+
+    template = env.get_template('src/index.html')
+    content = template.render()
+    html = BeautifulSoup(content, 'html.parser')
+    inline_script = html.select_one('body > script')
+
+    assert inline_script is not None
+
+    script_code = inline_script.string.strip()
+
+    # generate the sha256 of the script code and base64 encode it
+    script_code_sha256 = base64.b64encode(
+                                hashlib.sha256(
+                                    script_code.encode('utf-8')).digest())
+
+    assert script_code_sha256 == script_sha256_base64_encoded


### PR DESCRIPTION
We use the GOVUK Frontend library template.html
file as the base layout of our pages. It includes
an inline script which our Content Security Policy
allows by referencing a sha256 of its contents.

This adds a test to check the script's contents
match the sha256. If this test fails, the sha256
has changed and so the sha256 in our Content
Security Policy will need to be updated to the new
value.

Part of this story:

https://www.pivotaltracker.com/story/show/177597156

The Content Security Policy is added here:

https://github.com/alphagov/notifications-broadcasts-infra/blob/main/terraform/modules/govuk-alerts-website/files/main.py

It is tested here:

https://github.com/alphagov/notifications-broadcasts-infra/blob/main/terraform/modules/govuk-alerts-website/files/test_inject_headers.py

Both contain references to the sha256.