### PR TITLE
Update GOV.UK Frontend to get new link styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4715,9 +4715,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
-      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
+      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA==",
       "dev": true
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "fibers": "^5.0.0",
-    "govuk-frontend": "^3.11.0",
+    "govuk-frontend": "^3.12.0",
     "gulp": "^4.0.2",
     "gulp-if": "^3.0.0",
     "gulp-postcss": "^9.0.0",

--- a/src/assets/stylesheets/_govuk_frontend.scss
+++ b/src/assets/stylesheets/_govuk_frontend.scss
@@ -6,6 +6,7 @@
 
 // set asset URL root to match that of application
 $govuk-assets-path: "/alerts/assets/";
+$govuk-new-link-styles: true;
 
 @import "govuk/base";
 


### PR DESCRIPTION
For more details see https://github.com/alphagov/govuk-frontend/releases/tag/v3.12.0

# Before 

![image](https://user-images.githubusercontent.com/355079/122377704-356a5000-cf5d-11eb-9d23-bf4b652758a4.png)

# After 

![image](https://user-images.githubusercontent.com/355079/122377756-40bd7b80-cf5d-11eb-8f3d-59413b5168c1.png)
