### PR TITLE
Remove today’s test from the planned tests page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -44,7 +44,7 @@
   {{ banner(alerts.current | length, alerts.last_updated_date) }}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ planned_tests_banner(3, "Thursday 17 June to Tuesday 29 June") }}
+    {{ planned_tests_banner(2, "Friday 18 June and Tuesday 29 June") }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -40,33 +40,6 @@
       </h1>
 
       <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
-        Thursday 17 June 2021
-      </h2>
-      <h3 class="govuk-body govuk-!-margin-bottom-6">
-        Across the UK
-      </h3>
-      <p class="govuk-body">
-        Mobile phone networks in the UK are testing emergency alerts between midday and 2pm.
-      </p>
-      <p class="govuk-body">
-        You may get a test alert if you have an Android phone or tablet. If you get an alert, your device may make a loud siren-like sound.
-      </p>
-      <p class="govuk-body">
-        The alerts will say:
-      </p>
-      <div class="govuk-inset-text govuk-!-margin-top-2">
-        <p class="govuk-body">
-          This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
-        </p>
-      </div>
-      <p class="govuk-body">
-        You may get the same alert twice.
-      </p>
-      <p class="govuk-body">
-        You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-tests">opt out of mobile phone network tests</a>.
-      </p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
         Friday 18 June 2021
       </h2>
       <h3 class="govuk-body govuk-!-margin-bottom-6">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -46,10 +46,10 @@
         Across the UK
       </h3>
       <p class="govuk-body">
-        Mobile phone networks in the UK are testing emergency alerts.
+        Some mobile phone networks in the UK are testing emergency alerts.
       </p>
       <p class="govuk-body">
-        You may get a test alert if you have an Android phone or tablet. If you get an alert, your device may make a loud siren-like sound.
+        If you have an Android device, there’s a small chance you may get a test alert. Your device may make a loud siren-like sound.
       </p>
       <p class="govuk-body">
         The alert will say:


### PR DESCRIPTION
It’s over now.

Also makes it clearer that most people probably won’t get an alert during one of these tests.