### PR TITLE
Fix links that don’t have the govuk-link class

### DIFF
--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -61,7 +61,7 @@
         Mobile phone network tests
       </h3>
       <p class="govuk-body">
-        If you have an Android device, there’s a small chance you may get <a href="/alerts/planned-tests">test alerts</a> from your mobile network operator.
+        If you have an Android device, there’s a small chance you may get <a class="govuk-link" href="/alerts/planned-tests">test alerts</a> from your mobile network operator.
       </p>
       {% set testAlertButton %}
         If you want to opt out of mobile network operator alerts

--- a/src/reasons-you-might-get-an-alert.html
+++ b/src/reasons-you-might-get-an-alert.html
@@ -39,7 +39,7 @@
         Reasons you might get an emergency alert
       </h1>
       <p class="govuk-body">
-        The government and mobile phone networks are <a href="/alerts/planned-tests">testing emergency alerts</a>.
+        The government and mobile phone networks are <a class="govuk-link" href="/alerts/planned-tests">testing emergency alerts</a>.
       </p>
       <p class="govuk-body">
         If there’s a test in your local area, you might get an alert.
@@ -70,7 +70,7 @@
       <p class="govuk-body">
        For most people, the chance of receiving an alert will be low.
       </p>
-      
+
     </div>
   </div>
 {% endblock %}

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -40,7 +40,7 @@
         When you get an emergency alert
       </h1>
       <p class="govuk-body">
-        Your phone or tablet may: 
+        Your phone or tablet may:
       </p>
       <ul class="govuk-list govuk-list--bullet">
         <li>
@@ -63,13 +63,13 @@
         Sometimes an alert will include a phone number or a link to the GOV.UK website for more information.
       </p>
       <div class="govuk-inset-text">
-        <p>The government and mobile phone networks are <a href="/alerts/planned-tests">testing emergency alerts</a>. You may get an alert if you live in, or travel through, a test area.</p>
+        <p>The government and mobile phone networks are <a class="govuk-link" href="/alerts/planned-tests">testing emergency alerts</a>. You may get an alert if you live in, or travel through, a test area.</p>
       </div>
       <h2 class="govuk-heading-m">
         If you’re driving or riding when you get an alert
       </h2>
       <p class="govuk-body">
-        Find somewhere safe to stop before using your phone or tablet. 
+        Find somewhere safe to stop before using your phone or tablet.
       </p>
       <p class="govuk-body">
         It is illegal to use a hand-held device while driving or riding.
@@ -78,10 +78,10 @@
         If you want to see an alert again
       </h2>
       <p class="govuk-body">
-        You can find <a href="/alerts/current-alerts">current alerts</a> and <a href="/alerts/past-alerts">past alerts</a> at gov.uk/alerts.
+        You can find <a class="govuk-link" href="/alerts/current-alerts">current alerts</a> and <a class="govuk-link" href="/alerts/past-alerts">past alerts</a> at gov.uk/alerts.
       </p>
       <p class="govuk-body">
-        You can also search for them on your phone or tablet. 
+        You can also search for them on your phone or tablet.
       </p>
       {% set androidButton %}
         <span class="govuk-visually-hidden">Find alerts on </span>Android phones and tablets

--- a/tests/test_local_links.py
+++ b/tests/test_local_links.py
@@ -87,3 +87,13 @@ def test_local_links_lead_to_existing_routes_in_pages_with_alerts(env, alert_dic
         for link in local_links:
             path = urlparse(link['href']).path
             assert path in local_routes
+
+
+@pytest.mark.parametrize('template_path', all_templates_except_alerts)
+def test_links_have_correct_class_attribute(env, alert_dict, template_path):
+    html = get_page_html(
+        env,
+        re.sub(r'^\./{1}', '', template_path),
+    )
+    for link in html.select('main a'):
+        assert 'govuk-link' in link['class']


### PR DESCRIPTION
They won’t have the correct colour or nice underline without this class.