### PR TITLE
Make devices explicit for the Reading test

### DIFF
--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -73,7 +73,7 @@
         The UK government will send a test alert between 1pm and 2pm.
       </p>
       <p class="govuk-body">
-        If you get an alert, your phone or tablet may make a loud siren-like sound. You do not need to take any action.
+        If you have an iPhone or Android device you may get an alert. Your device may make a loud siren-like sound. You do not need to take any action.
       </p>
       <p class="govuk-body">
         The alert will say:


### PR DESCRIPTION
To differentiate it from the planned operator test, which is only for Android devices.