### PR TITLE
Remove the 22 June test from planned tests page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -44,7 +44,7 @@
   {{ banner(alerts.current | length, alerts.last_updated_date) }}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ planned_tests_banner(2, "Tuesday 22 June and Tuesday 29 June") }}
+    {{ planned_tests_banner(1, "Tuesday 29 June") }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -40,30 +40,6 @@
       </h1>
 
       <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
-        Tuesday 22 June 2021
-      </h2>
-      <h3 class="govuk-body govuk-!-margin-bottom-6">
-        Across the UK
-      </h3>
-      <p class="govuk-body">
-        Some mobile phone networks in the UK are testing emergency alerts between 1pm and 2pm.
-      </p>
-      <p class="govuk-body">
-        If you have an Android device, there’s a small chance you may get a test alert. Your device may make a loud siren-like sound.
-      </p>
-      <p class="govuk-body">
-        The alert will say:
-      </p>
-      <div class="govuk-inset-text govuk-!-margin-top-2">
-        <p class="govuk-body">
-          This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
-        </p>
-      </div>
-      <p class="govuk-body">
-        You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-tests">opt out of mobile phone network tests</a>.
-      </p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
         Tuesday 29 June 2021
       </h2>
       <h3 class="govuk-body govuk-!-margin-bottom-6">


### PR DESCRIPTION
It’s over now.

This PR should be merged at the end of today (22 June)