### PR TITLE
Fix og:url for planned tests page

### DIFF
--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -9,7 +9,7 @@
   {{ metaTags(
     description="Planned tests of the Emergency Alerts service",
     title=pageTitle,
-    url="https://www.gov.uk/alerts/opt-out"
+    url="https://www.gov.uk/alerts/planned-tests"
   ) }}
 {% endblock %}
 


### PR DESCRIPTION
It’s pointing to the wrong place, which can cause the wrong preview to show when the link is shared on social media.

![image](https://user-images.githubusercontent.com/355079/123060401-9cc34c80-d402-11eb-846f-28dc5e3a42c6.png)
