### PR TITLE
Remove planned tests banner and content

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -42,9 +42,6 @@
   {% if alerts.current %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ banner(alerts.current | length, alerts.last_updated_date) }}
-  {% else %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ planned_tests_banner(1, "Tuesday 29 June") }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -39,32 +39,13 @@
         {{ pageTitle }}
       </h1>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
-        Tuesday 29 June 2021
-      </h2>
-      <h3 class="govuk-body govuk-!-margin-bottom-6">
-        Reading, Berkshire
-      </h3>
       <p class="govuk-body">
-        The UK government will send a test alert between 1pm and 2pm.
+        There are currently no planned tests of emergency alerts.
       </p>
+
       <p class="govuk-body">
-        If you have an iPhone or Android device you may get an alert. Your device may make a loud siren-like sound. You do not need to take any action.
+        See <a class="govuk-link" href="/alerts/past-alerts">past alerts</a>.
       </p>
-      <p class="govuk-body">
-        The alert will say:
-      </p>
-      <div class="govuk-inset-text govuk-!-margin-top-2">
-        <p class="govuk-body">
-          The UK government is testing Emergency Alerts in Reading, Berkshire.
-        </p>
-        <p class="govuk-body">
-          Emergency alerts tell you what to do if there’s a life-threatening event nearby.
-        </p>
-        <p class="govuk-body">
-          To find out more, call 0808 1697692 or search for gov.uk/alerts
-        </p>
-      </div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178622042

We should keep the page in case it's been indexed or bookmarked,
as well as to confirm what the future plans are.

## Screenshot

![screencapture-localhost-8000-alerts-planned-tests-2021-06-28-14_54_25](https://user-images.githubusercontent.com/9029009/123648339-c6281200-d820-11eb-86d1-6ec9fbdbb12a.png)

