### PR TITLE
Reorder past alerts

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -1,19 +1,4 @@
 alerts:
-  - identifier: 3-may-2021
-    message_type: alert
-    sent: 2021-05-25T12:50:00+01:00
-    starts: 2021-05-25T13:00:00+01:00
-    expires: 2021-05-25T14:00:00+01:00
-    headline: Emergency alert
-    description: |
-      The UK government is testing Emergency Alerts in East Suffolk.
-
-      Emergency alerts tell you what to do if there’s a life-threatening event nearby.
-
-      To find out more, call 0808 1697692 or search for gov.uk/alerts
-    static_map_png: map-sizewell-demo-static.png
-    area_names:
-      - Leiston in East Suffolk
   - identifier: 29-june-2021
     message_type: alert
     sent: 2021-06-29T12:45:00+01:00
@@ -29,3 +14,18 @@ alerts:
     static_map_png: map-reading-demo-static.png
     area_names:
       - Reading, Berkshire
+  - identifier: 3-may-2021
+    message_type: alert
+    sent: 2021-05-25T12:50:00+01:00
+    starts: 2021-05-25T13:00:00+01:00
+    expires: 2021-05-25T14:00:00+01:00
+    headline: Emergency alert
+    description: |
+      The UK government is testing Emergency Alerts in East Suffolk.
+
+      Emergency alerts tell you what to do if there’s a life-threatening event nearby.
+
+      To find out more, call 0808 1697692 or search for gov.uk/alerts
+    static_map_png: map-sizewell-demo-static.png
+    area_names:
+      - Leiston in East Suffolk


### PR DESCRIPTION
They appear to be shown in the order they are in the yaml file

The quickest way to fix this is to swap the order. It works locally.

In time we may want a smarter way for this though where they are sorted
automatically

<img width="989" alt="Screenshot 2021-06-29 at 14 14 07" src="https://user-images.githubusercontent.com/7228605/123803787-7d399180-d8e4-11eb-8801-2640f6f87395.png">
