### PR TITLE
Update network operator test content

### DIFF
--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -60,16 +60,13 @@
       <h3 class="govuk-heading-s" id="mobile-network-tests">
         Mobile network operator tests
       </h3>
+      <p class="govuk-body">
+        To opt out of mobile network operator tests, search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
+      </p>
       {% set testAlertButton %}
-        How to opt out of mobile network operator tests
+      If you cannot see <b class="govuk-!-font-weight-bold">Test alerts</b>
       {% endset %}
       {% set testAlertAdvice %}
-        <p class="govuk-body">
-          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
-        </p>
-        <p class="govuk-body">
-          If you cannot see <b class="govuk-!-font-weight-bold">Test alerts</b>:
-        </p>
         <ul class="govuk-list govuk-list--number">
           <li>
             Open your phone calling app.

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -58,20 +58,20 @@
         If this does not work, contact your device manufacturer.
       </p>
       <h3 class="govuk-heading-s" id="mobile-network-tests">
-        Mobile phone network tests
+        Mobile network operator tests
       </h3>
       <p class="govuk-body">
         If you have an Android device, there’s a small chance you may get <a class="govuk-link" href="/alerts/planned-tests">test alerts</a> from your mobile network operator.
       </p>
       {% set testAlertButton %}
-        If you want to opt out of mobile network operator alerts
+        How to opt out of mobile network operator tests
       {% endset %}
       {% set testAlertAdvice %}
         <p class="govuk-body">
           Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
         </p>
         <p class="govuk-body">
-          If you can’t see <b class="govuk-!-font-weight-bold">Test alerts</b>:
+          If you cannot see <b class="govuk-!-font-weight-bold">Test alerts</b>:
         </p>
         <ul class="govuk-list govuk-list--number">
           <li>

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -61,9 +61,6 @@
         Mobile network operator tests
       </h3>
       <p class="govuk-body">
-        Mobile phone networks in the UK are testing emergency alerts.
-      </p>
-      <p class="govuk-body">
         If you have an Android device, there’s a small chance you may get <a class="govuk-link" href="/alerts/planned-tests">test alerts</a> from your mobile network operator.
       </p>
       {% set testAlertButton %}

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -60,9 +60,6 @@
       <h3 class="govuk-heading-s" id="mobile-network-tests">
         Mobile network operator tests
       </h3>
-      <p class="govuk-body">
-        If you have an Android device, there’s a small chance you may get <a class="govuk-link" href="/alerts/planned-tests">test alerts</a> from your mobile network operator.
-      </p>
       {% set testAlertButton %}
         How to opt out of mobile network operator tests
       {% endset %}

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -58,7 +58,7 @@
         If this does not work, contact your device manufacturer.
       </p>
       <h3 class="govuk-heading-s" id="mobile-network-tests">
-        Mobile phone network tests
+        Mobile network operator tests
       </h3>
       <p class="govuk-body">
         Mobile phone networks in the UK are testing emergency alerts.

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -58,8 +58,11 @@
         If this does not work, contact your device manufacturer.
       </p>
       <h3 class="govuk-heading-s" id="mobile-network-tests">
-        Mobile network operator tests
+        Mobile phone network tests
       </h3>
+      <p class="govuk-body">
+        Mobile phone networks in the UK are testing emergency alerts.
+      </p>
       <p class="govuk-body">
         If you have an Android device, there’s a small chance you may get <a class="govuk-link" href="/alerts/planned-tests">test alerts</a> from your mobile network operator.
       </p>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -42,9 +42,6 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
         Friday 2 July 2021
       </h2>
-      <h3 class="govuk-body govuk-!-margin-bottom-6">
-        Various locations
-      </h3>
       <p class="govuk-body">
         Some mobile phone networks in the UK will test emergency alerts between midday and 2pm.
       </p>

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -39,13 +39,33 @@
         {{ pageTitle }}
       </h1>
 
+      <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
+        Friday 2 July 2021
+      </h2>
+      <h3 class="govuk-body govuk-!-margin-bottom-6">
+        Various locations
+      </h3>
       <p class="govuk-body">
-        There are currently no planned tests of emergency alerts.
+        Some mobile phone networks in the UK will test emergency alerts between midday and 2pm.
       </p>
+      <p class="govuk-body">
+        If you have an Android phone or tablet, there’s a small chance you’ll get a test alert.
+      </p>
+      <p class="govuk-body">
+        You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-tests">opt out of mobile network operator tests</a>.
+      </p>
+      <p class="govuk-body">
+        If you do get an alert, your device may make a loud siren-like sound for about 10 seconds.
+      </p>
+      <p class="govuk-body">
+        The alert will say:
+      </p>
+      <div class="govuk-inset-text govuk-!-margin-top-2">
+        <p class="govuk-body">
+          This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
+        </p>
+      </div>
 
-      <p class="govuk-body">
-        See <a class="govuk-link" href="/alerts/past-alerts">past alerts</a>.
-      </p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This PR updates the content on the following pages:

1. gov.uk/alerts/planned-tests
2. gov.uk/alerts/opt-out

## Changes

1. Add updated information about planned network operator tests
2. Make the content consistent with how we talk about network operator tests on `/planned-tests`