### PR TITLE
Add previous operator tests to the previous alerts page

### DIFF
--- a/build.py
+++ b/build.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
         template = env.get_template(str(page))
 
         if str(page) == 'src/alert.html':
-            for alert in alerts:
+            for alert in alerts.by_message_type('alert'):
                 target = ROOT / alert.identifier
                 target.open('w').write(template.render({'alert_data': alert}))
             continue

--- a/data.yaml
+++ b/data.yaml
@@ -14,6 +14,26 @@ alerts:
     static_map_png: map-reading-demo-static.png
     area_names:
       - Reading, Berkshire
+  - identifier:
+    message_type: operator
+    sent: 2021-06-22T12:00:00+01:00
+    starts:
+    expires:
+    headline:
+    description: |
+      This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
+    static_map_png:
+    area_names:
+  - identifier:
+    message_type: operator
+    sent: 2021-06-18T12:00:00+01:00
+    starts:
+    expires:
+    headline:
+    description: |
+      This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
+    static_map_png:
+    area_names:
   - identifier: 3-may-2021
     message_type: alert
     sent: 2021-05-25T12:50:00+01:00

--- a/data.yaml
+++ b/data.yaml
@@ -16,9 +16,9 @@ alerts:
       - Reading, Berkshire
   - identifier:
     message_type: operator
-    sent: 2021-06-22T12:00:00+01:00
-    starts:
-    expires:
+    sent: 2021-06-22T00:00:00+01:00
+    starts: 2021-06-22T00:00:00+01:00
+    expires: 2021-06-22T23:59:59+01:00
     headline:
     description: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
@@ -26,9 +26,9 @@ alerts:
     area_names:
   - identifier:
     message_type: operator
-    sent: 2021-06-18T12:00:00+01:00
-    starts:
-    expires:
+    sent: 2021-06-18T00:00:00+01:00
+    starts: 2021-06-18T00:00:00+01:00
+    expires: 2021-06-18T23:59:59+01:00
     headline:
     description: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -33,6 +33,8 @@ class Alert(SerialisedModel):
 
     @property
     def is_expired(self):
+        if self.message_type == 'operator':
+            return True
         now = datetime.now(pytz.utc)
         return self.expires_date.as_utc_datetime < now
 

--- a/lib/alert_date.py
+++ b/lib/alert_date.py
@@ -20,9 +20,14 @@ class AlertDate(object):
         ).lower()
 
     @property
+    def date_as_lang(self):
+        dt = self._local_datetime
+        return f'{dt:%A} {dt.day} {dt:%B} {dt:%Y}'
+
+    @property
     def as_lang(self, lang='en-GB'):
         dt = self._local_datetime
-        return f'at {self.time_as_lang} on {dt:%A} {dt.day} {dt:%B} {dt:%Y}'
+        return f'at {self.time_as_lang} on {self.date_as_lang}'
 
     @property
     def as_iso8601(self):

--- a/lib/alert_date.py
+++ b/lib/alert_date.py
@@ -26,7 +26,6 @@ class AlertDate(object):
 
     @property
     def as_lang(self, lang='en-GB'):
-        dt = self._local_datetime
         return f'at {self.time_as_lang} on {self.date_as_lang}'
 
     @property

--- a/lib/alerts.py
+++ b/lib/alerts.py
@@ -30,3 +30,8 @@ class Alerts(SerialisedModelCollection):
             data = yaml.load(stream, Loader=yaml.CLoader)
 
         return cls(data['alerts'])
+
+    def by_message_type(self, message_type):
+        return [
+            alert for alert in self if alert.message_type == message_type
+        ]

--- a/src/mobile-network-operator-tests.html
+++ b/src/mobile-network-operator-tests.html
@@ -1,0 +1,47 @@
+{% extends "templates/content.html" %}
+
+{%- from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs -%}
+{%- from "templates/components/alert.html" import alert -%}
+{%- from "templates/components/meta_tags.html" import metaTags -%}
+
+{% set pageTitle = "Mobile network operator tests" %}
+
+{% block metaTags %}
+  {{ metaTags(
+    description="About mobile network operator tests of Emergency Alerts",
+    title=pageTitle,
+    url="https://www.gov.uk/alerts/mobile-network-operator-tests"
+  ) }}
+{% endblock %}
+
+{% block prefetch %}
+  <link rel="prefetch" href="{{ '/alerts/assets/javascripts/govuk-frontend-details.js' | file_fingerprint }}" />
+{% endblock %}
+
+{% block pageTitleCurrent -%}
+  {{ pageTitle }}
+{%- endblock %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Home",
+        "href": "/"
+      },
+      {
+        "text": "Emergency alerts",
+        "href": "/alerts"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">
+    {{ pageTitle }}
+  </h1>
+  <p class="govuk-body">
+    TBC
+  </p>
+{% endblock %}

--- a/src/mobile-network-operator-tests.html
+++ b/src/mobile-network-operator-tests.html
@@ -42,6 +42,15 @@
     {{ pageTitle }}
   </h1>
   <p class="govuk-body">
-    TBC
+    Mobile phone networks are <a class="govuk-link" href="/alerts/planned-tests">testing emergency alerts</a> in the UK.
+  </p>
+  <p class="govuk-body">
+    You’ll only get test alerts from your mobile network operator if you have an Android phone or tablet with test alerts switched on.
+  </p>
+  <p class="govuk-body">
+    If you get an alert, your device may make a loud siren-like sound for about 10 seconds.
+  </p>
+  <p class="govuk-body">
+    You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-operator-tests">opt out of network operator tests</a>.
   </p>
 {% endblock %}

--- a/src/mobile-network-operator-tests.html
+++ b/src/mobile-network-operator-tests.html
@@ -38,19 +38,23 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">
-    {{ pageTitle }}
-  </h1>
-  <p class="govuk-body">
-    Mobile phone networks are <a class="govuk-link" href="/alerts/planned-tests">testing emergency alerts</a> in the UK.
-  </p>
-  <p class="govuk-body">
-    You’ll only get test alerts from your mobile network operator if you have an Android phone or tablet with test alerts switched on.
-  </p>
-  <p class="govuk-body">
-    If you get an alert, your device may make a loud siren-like sound for about 10 seconds.
-  </p>
-  <p class="govuk-body">
-    You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-operator-tests">opt out of network operator tests</a>.
-  </p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        {{ pageTitle }}
+      </h1>
+      <p class="govuk-body">
+        Mobile phone networks are <a class="govuk-link" href="/alerts/planned-tests">testing emergency alerts</a> in the UK.
+      </p>
+      <p class="govuk-body">
+        You’ll only get test alerts from your mobile network operator if you have an Android phone or tablet with test alerts switched on.
+      </p>
+      <p class="govuk-body">
+        If you get an alert, your device may make a loud siren-like sound for about 10 seconds.
+      </p>
+      <p class="govuk-body">
+        You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-operator-tests">opt out of network operator tests</a>.
+      </p>
+    </div>
+  </div>
 {% endblock %}

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -48,7 +48,7 @@
       <p class="govuk-body">
         Because of this, you should keep emergency alerts switched on for your own safety.
       </p>
-      <h2 class="govuk-heading-m">
+      <h2 class="govuk-heading-l">
         Android phones and tablets
       </h2>
       <p class="govuk-body">
@@ -83,7 +83,7 @@
         "summaryHtml": testAlertButton,
         "html": testAlertAdvice
       }) }}
-      <h2 class="govuk-heading-m">
+      <h2 class="govuk-heading-l">
         iPhone
       </h2>
       <p class="govuk-body">

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -58,21 +58,15 @@
         If this does not work, contact your device manufacturer.
       </p>
       <h3 class="govuk-heading-s" id="mobile-network-tests">
-        Mobile phone network tests
+        Mobile network operator tests
       </h3>
       <p class="govuk-body">
-        If you have an Android device, there’s a small chance you may get <a class="govuk-link" href="/alerts/planned-tests">test alerts</a> from your mobile network operator.
+        To opt out of mobile network operator tests, search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
       </p>
       {% set testAlertButton %}
-        If you want to opt out of mobile network operator alerts
+      If you cannot see <b class="govuk-!-font-weight-bold">Test alerts</b>
       {% endset %}
       {% set testAlertAdvice %}
-        <p class="govuk-body">
-          Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
-        </p>
-        <p class="govuk-body">
-          If you can’t see <b class="govuk-!-font-weight-bold">Test alerts</b>:
-        </p>
         <ul class="govuk-list govuk-list--number">
           <li>
             Open your phone calling app.

--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -57,7 +57,7 @@
       <p class="govuk-body">
         If this does not work, contact your device manufacturer.
       </p>
-      <h3 class="govuk-heading-s" id="mobile-network-tests">
+      <h3 class="govuk-heading-s" id="mobile-network-operator-tests">
         Mobile network operator tests
       </h3>
       <p class="govuk-body">

--- a/src/past-alerts.html
+++ b/src/past-alerts.html
@@ -42,11 +42,14 @@
     {{ pageTitle }}
   </h1>
   {% for previous_alert in alerts.expired %}
+  <h2 class="govuk-heading-m {% if not loop.first %}govuk-!-margin-top-9{% endif %}">
+    {{ previous_alert.sent_date.date_as_lang }}
+  </h2>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ alert(alert=previous_alert) }}
   {% endfor %}
   {% if alerts.expired %}
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {% else %}
   <p class="govuk-body">There are no past emergency alerts.</p>
   {% endif %}

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -6,13 +6,23 @@
       <div class="alerts-icon__container alerts-icon__container--48">
         {{ alerts_icon(height=48, alert_active=alert.is_current) }}
         <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
-          <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.area_names | formatted_list(before_each='', after_each='') }}
+          {% if alert.message_type == 'operator' %}
+            Mobile network operator test
+          {% else %}
+            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.area_names | formatted_list(before_each='', after_each='') }}
+          {% endif %}
         </h2>
         {{ alert.description | paragraphize }}
-        <a href="/alerts/{{ alert.identifier }}" class="govuk-link govuk-body">
-          More information about this alert
-          <span class="govuk-visually-hidden">to {{ alert.area_names | formatted_list(before_each='', after_each='') }}</span>
-        </a>
+        {% if alert.message_type == 'operator' %}
+          <a href="/alerts/mobile-network-operator-tests" class="govuk-link govuk-body">
+            More information about mobile network operator tests
+          </a>
+        {% else %}
+          <a href="/alerts/{{ alert.identifier }}" class="govuk-link govuk-body">
+            More information about this alert
+            <span class="govuk-visually-hidden">to {{ alert.area_names | formatted_list(before_each='', after_each='') }}</span>
+          </a>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
So if you have received one of these we are acknowledging it happened, even if we’ve taken it off the planned tests page.

New page structure looks like:

![image](https://user-images.githubusercontent.com/355079/124152395-65504200-da8b-11eb-9a3d-99e14c1962ab.png)
