### PR TITLE
Move the 2 July operator test to the past alerts page

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -1,4 +1,14 @@
 alerts:
+  - identifier:
+    message_type: operator
+    sent: 2021-07-02T00:00:00+01:00
+    starts: 2021-07-02T10:00:00+01:00
+    expires: 2021-07-02T12:00:00+01:00
+    headline:
+    description: |
+      This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
+    static_map_png:
+    area_names:
   - identifier: 29-june-2021
     message_type: alert
     sent: 2021-06-29T12:45:00+01:00

--- a/src/index.html
+++ b/src/index.html
@@ -42,9 +42,6 @@
   {% if alerts.current %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ banner(alerts.current | length, alerts.last_updated_date) }}
-  {% else %}
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  {{ planned_tests_banner(1, 'Friday 2 July 2021') }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -38,27 +38,12 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-6">
-        Friday 2 July 2021
-      </h2>
       <p class="govuk-body">
-        Some mobile phone networks in the UK will test emergency alerts between 10am and midday.
+        There are currently no planned tests of emergency alerts.
       </p>
       <p class="govuk-body">
-        Most phones and tablets will not get a test alert.
+        See the <a class="govuk-link" href="/alerts/past-alerts">past alerts</a> page for previous tests.
       </p>
-      <p class="govuk-body">
-        Find out more <a class="govuk-link" href="/alerts/mobile-network-operator-tests">about mobile network operator tests</a>.
-      </p>
-      <p class="govuk-body">
-        The alert will say:
-      </p>
-      <div class="govuk-inset-text govuk-!-margin-top-2">
-        <p class="govuk-body">
-          This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
-        </p>
-      </div>
     </div>
   </div>
 {% endblock %}

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -42,7 +42,7 @@
         There are currently no planned tests of emergency alerts.
       </p>
       <p class="govuk-body">
-        See the <a class="govuk-link" href="/alerts/past-alerts">past alerts</a> page for previous tests.
+        You can see previous tests on the <a class="govuk-link" href="/alerts/past-alerts">past alerts page</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
It’s over now.