### PR TITLE
Remove redundant 'headline' field

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -4,7 +4,6 @@ alerts:
     sent: 2021-07-16T00:00:00+01:00
     starts: 2021-07-16T13:00:00+01:00
     expires: 2021-07-16T14:00:00+01:00
-    headline:
     description: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     static_map_png:
@@ -14,7 +13,6 @@ alerts:
     sent: 2021-07-14T00:00:00+01:00
     starts: 2021-07-14T13:00:00+01:00
     expires: 2021-07-14T14:00:00+01:00
-    headline:
     description: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     static_map_png:
@@ -24,7 +22,6 @@ alerts:
     sent: 2021-07-09T00:00:00+01:00
     starts: 2021-07-09T13:00:00+01:00
     expires: 2021-07-09T14:00:00+01:00
-    headline:
     description: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     static_map_png:
@@ -34,7 +31,6 @@ alerts:
     sent: 2021-07-02T00:00:00+01:00
     starts: 2021-07-02T10:00:00+01:00
     expires: 2021-07-02T12:00:00+01:00
-    headline:
     description: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     static_map_png:
@@ -44,7 +40,6 @@ alerts:
     sent: 2021-06-29T12:45:00+01:00
     starts: 2021-06-29T13:00:00+01:00
     expires: 2021-06-29T14:00:00+01:00
-    headline: Emergency alert
     description: |
       The UK government is testing Emergency Alerts in Reading, Berkshire.
 
@@ -59,7 +54,6 @@ alerts:
     sent: 2021-06-22T00:00:00+01:00
     starts: 2021-06-22T00:00:00+01:00
     expires: 2021-06-22T23:59:59+01:00
-    headline:
     description: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     static_map_png:
@@ -69,7 +63,6 @@ alerts:
     sent: 2021-06-18T00:00:00+01:00
     starts: 2021-06-18T00:00:00+01:00
     expires: 2021-06-18T23:59:59+01:00
-    headline:
     description: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     static_map_png:
@@ -79,7 +72,6 @@ alerts:
     sent: 2021-05-25T12:50:00+01:00
     starts: 2021-05-25T13:00:00+01:00
     expires: 2021-05-25T14:00:00+01:00
-    headline: Emergency alert
     description: |
       The UK government is testing Emergency Alerts in East Suffolk.
 

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -13,7 +13,6 @@ class Alert(SerialisedModel):
         'starts',
         'sent',
         'expires',
-        'headline',
         'description',
         'static_map_png',
         'area_names',

--- a/src/alert.html
+++ b/src/alert.html
@@ -47,7 +47,7 @@
 {% block mainContent %}
   <h1 class="govuk-heading-xl alerts-icon__container alerts-icon__container--48">
     {{ alerts_icon(height=48, alert_active=alert_data.is_current) }}
-    {{ alert_data.headline }}
+    Emergency alert
   </h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds alert-icon__container">


### PR DESCRIPTION
Small contribution to: https://www.pivotaltracker.com/story/show/178774818

This is only used for "alert" messages (noting that the "operator"
ones don't have their own page [1]) and is always set to the same
text. Although this field is shown in the UI [2] it's not actually
used [3] or stored in the DB.

[1]: https://github.com/alphagov/notifications-govuk-alerts/blob/db69aa1e9db89ec063733a0e48d99a0cf5fb71a6/build.py#L48
[2]: https://github.com/alphagov/notifications-admin/blob/d414e6d345930f9a47ed1fc2fe0faf99d3769840/app/templates/views/broadcast/write-new-broadcast.html#L22
[3]: https://github.com/alphagov/notifications-admin/blob/d414e6d345930f9a47ed1fc2fe0faf99d3769840/app/main/views/broadcast.py#L147-L151