### PR TITLE
Fix and standardise filtering on alert types

### DIFF
--- a/build.py
+++ b/build.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
         template = env.get_template(str(page))
 
         if str(page) == 'src/alert.html':
-            for alert in alerts.by_message_type('alert'):
+            for alert in alerts.public:
                 target = ROOT / alert.identifier
                 target.open('w').write(template.render({'alert_data': alert}))
             continue

--- a/data.yaml
+++ b/data.yaml
@@ -1,6 +1,6 @@
 alerts:
   - identifier:
-    message_type: operator
+    channel: operator
     sent: 2021-07-28T00:00:00+01:00
     starts: 2021-07-28T13:00:00+01:00
     expires: 2021-07-28T14:00:00+01:00
@@ -10,6 +10,7 @@ alerts:
     area_names:
   - identifier:
     message_type: operator
+    channel: operator
     sent: 2021-07-16T00:00:00+01:00
     starts: 2021-07-16T13:00:00+01:00
     expires: 2021-07-16T14:00:00+01:00
@@ -18,7 +19,7 @@ alerts:
     static_map_png:
     area_names:
   - identifier:
-    message_type: operator
+    channel: operator
     sent: 2021-07-14T00:00:00+01:00
     starts: 2021-07-14T13:00:00+01:00
     expires: 2021-07-14T14:00:00+01:00
@@ -27,7 +28,7 @@ alerts:
     static_map_png:
     area_names:
   - identifier:
-    message_type: operator
+    channel: operator
     sent: 2021-07-09T00:00:00+01:00
     starts: 2021-07-09T13:00:00+01:00
     expires: 2021-07-09T14:00:00+01:00
@@ -36,7 +37,7 @@ alerts:
     static_map_png:
     area_names:
   - identifier:
-    message_type: operator
+    channel: operator
     sent: 2021-07-02T00:00:00+01:00
     starts: 2021-07-02T10:00:00+01:00
     expires: 2021-07-02T12:00:00+01:00
@@ -45,7 +46,7 @@ alerts:
     static_map_png:
     area_names:
   - identifier: 29-june-2021
-    message_type: alert
+    channel: severe
     sent: 2021-06-29T12:45:00+01:00
     starts: 2021-06-29T13:00:00+01:00
     expires: 2021-06-29T14:00:00+01:00
@@ -59,7 +60,7 @@ alerts:
     area_names:
       - Reading, Berkshire
   - identifier:
-    message_type: operator
+    channel: operator
     sent: 2021-06-22T00:00:00+01:00
     starts: 2021-06-22T00:00:00+01:00
     expires: 2021-06-22T23:59:59+01:00
@@ -68,7 +69,7 @@ alerts:
     static_map_png:
     area_names:
   - identifier:
-    message_type: operator
+    channel: operator
     sent: 2021-06-18T00:00:00+01:00
     starts: 2021-06-18T00:00:00+01:00
     expires: 2021-06-18T23:59:59+01:00
@@ -77,7 +78,7 @@ alerts:
     static_map_png:
     area_names:
   - identifier: 3-may-2021
-    message_type: alert
+    channel: severe
     sent: 2021-05-25T12:50:00+01:00
     starts: 2021-05-25T13:00:00+01:00
     expires: 2021-05-25T14:00:00+01:00

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -35,10 +35,6 @@ class Alert(SerialisedModel):
         return self.is_current and self.is_public
 
     @property
-    def is_expired_or_test(self):
-        return self.is_expired or not self.is_public
-
-    @property
     def is_public(self):
         return self.channel in ['government', 'severe']
 

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -9,7 +9,7 @@ from lib.alert_date import AlertDate
 class Alert(SerialisedModel):
     ALLOWED_PROPERTIES = {
         'identifier',
-        'message_type',
+        'channel',
         'starts',
         'sent',
         'expires',
@@ -40,7 +40,7 @@ class Alert(SerialisedModel):
 
     @property
     def is_public(self):
-        return self.message_type == 'alert'
+        return self.channel in ['government', 'severe']
 
     @property
     def is_expired(self):

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -31,9 +31,19 @@ class Alert(SerialisedModel):
         return AlertDate(self.expires)
 
     @property
+    def is_current_and_public(self):
+        return self.is_current and self.is_public
+
+    @property
+    def is_expired_or_test(self):
+        return self.is_expired or not self.is_public
+
+    @property
+    def is_public(self):
+        return self.message_type == 'alert'
+
+    @property
     def is_expired(self):
-        if self.message_type == 'operator':
-            return True
         now = datetime.now(pytz.utc)
         return self.expires_date.as_utc_datetime < now
 

--- a/lib/alerts.py
+++ b/lib/alerts.py
@@ -13,8 +13,8 @@ class Alerts(SerialisedModelCollection):
         return [alert for alert in self if alert.is_current_and_public]
 
     @property
-    def expired_or_test(self):
-        return [alert for alert in self if alert.is_expired_or_test]
+    def expired(self):
+        return [alert for alert in self if alert.is_expired]
 
     @property
     def public(self):

--- a/lib/alerts.py
+++ b/lib/alerts.py
@@ -9,16 +9,16 @@ class Alerts(SerialisedModelCollection):
     model = Alert
 
     @property
-    def current(self):
-        return [alert for alert in self if alert.is_current]
+    def current_and_public(self):
+        return [alert for alert in self if alert.is_current_and_public]
 
     @property
-    def expired(self):
-        return [alert for alert in self if alert.is_expired]
+    def expired_or_test(self):
+        return [alert for alert in self if alert.is_expired_or_test]
 
     @property
     def last_updated(self):
-        return max(alert.starts for alert in self if alert.is_current)
+        return max(alert.starts for alert in self.current_and_public)
 
     @property
     def last_updated_date(self):

--- a/lib/alerts.py
+++ b/lib/alerts.py
@@ -17,6 +17,10 @@ class Alerts(SerialisedModelCollection):
         return [alert for alert in self if alert.is_expired_or_test]
 
     @property
+    def public(self):
+        return [alert for alert in self if alert.is_public]
+
+    @property
     def last_updated(self):
         return max(alert.starts for alert in self.current_and_public)
 
@@ -30,8 +34,3 @@ class Alerts(SerialisedModelCollection):
             data = yaml.load(stream, Loader=yaml.CLoader)
 
         return cls(data['alerts'])
-
-    def by_message_type(self, message_type):
-        return [
-            alert for alert in self if alert.message_type == message_type
-        ]

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,4 +4,5 @@ isort==5.8.0
 flake8==3.9.1
 freezegun==1.1.0
 pytest==6.2.3
+pytest-mock==3.6.1
 beautifulsoup4==4.9.3

--- a/src/alert.html
+++ b/src/alert.html
@@ -22,7 +22,7 @@
   {{ pageTitle }}
 {%- endblock %}
 
-{% if alert_data.is_expired_or_test %}
+{% if alert_data.is_expired %}
   {% set parentBreadcrumb = {"text": "Past alerts", "href": "/alerts/past-alerts"} %}
 {% else %}
   {% set parentBreadcrumb = {"text": "Current alerts", "href": "/alerts/current-alerts"} %}

--- a/src/alert.html
+++ b/src/alert.html
@@ -22,7 +22,7 @@
   {{ pageTitle }}
 {%- endblock %}
 
-{% if alert_data.is_expired %}
+{% if alert_data.is_expired_or_test %}
   {% set parentBreadcrumb = {"text": "Past alerts", "href": "/alerts/past-alerts"} %}
 {% else %}
   {% set parentBreadcrumb = {"text": "Current alerts", "href": "/alerts/current-alerts"} %}

--- a/src/current-alerts.html
+++ b/src/current-alerts.html
@@ -41,11 +41,12 @@
   <h1 class="govuk-heading-xl">
     Current alerts
   </h1>
-  {% for current_alert in alerts.current %}
+  {% for current_alert in alerts.current_and_public %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ alert(alert=current_alert) }}
   {% endfor %}
-  {% if alerts.current %}
+
+  {% if alerts.current_and_public %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">
   {% else %}
   <p class="govuk-body">There are no current emergency alerts.</p>

--- a/src/past-alerts.html
+++ b/src/past-alerts.html
@@ -41,7 +41,7 @@
   <h1 class="govuk-heading-xl">
     {{ pageTitle }}
   </h1>
-  {% for past_alert in alerts.expired_or_test %}
+  {% for past_alert in alerts.expired %}
   <h2 class="govuk-heading-m {% if not loop.first %}govuk-!-margin-top-9{% endif %}">
     {{ past_alert.sent_date.date_as_lang }}
   </h2>
@@ -49,7 +49,7 @@
   {{ alert(alert=past_alert) }}
   {% endfor %}
 
-  {% if alerts.expired_or_test %}
+  {% if alerts.expired %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {% else %}
   <p class="govuk-body">There are no past emergency alerts.</p>

--- a/src/past-alerts.html
+++ b/src/past-alerts.html
@@ -41,15 +41,16 @@
   <h1 class="govuk-heading-xl">
     {{ pageTitle }}
   </h1>
-  {% for previous_alert in alerts.expired %}
+  {% for past_alert in alerts.expired_or_test %}
   <h2 class="govuk-heading-m {% if not loop.first %}govuk-!-margin-top-9{% endif %}">
-    {{ previous_alert.sent_date.date_as_lang }}
+    {{ past_alert.sent_date.date_as_lang }}
   </h2>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  {{ alert(alert=previous_alert) }}
+  {{ alert(alert=past_alert) }}
   {% endfor %}
-  {% if alerts.expired %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  {% if alerts.expired_or_test %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {% else %}
   <p class="govuk-body">There are no past emergency alerts.</p>
   {% endif %}

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -6,21 +6,21 @@
       <div class="alerts-icon__container alerts-icon__container--48">
         {{ alerts_icon(height=48, alert_active=alert.is_current) }}
         <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
-          {% if alert.channel == 'operator' %}
-            Mobile network operator test
-          {% else %}
+          {% if alert.is_public %}
             <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.area_names | formatted_list(before_each='', after_each='') }}
+          {% else %}
+            Mobile network operator test
           {% endif %}
         </h2>
         {{ alert.description | paragraphize }}
-        {% if alert.channel == 'operator' %}
-          <a href="/alerts/mobile-network-operator-tests" class="govuk-link govuk-body">
-            More information about mobile network operator tests
-          </a>
-        {% else %}
+        {% if alert.is_public %}
           <a href="/alerts/{{ alert.identifier }}" class="govuk-link govuk-body">
             More information about this alert
             <span class="govuk-visually-hidden">to {{ alert.area_names | formatted_list(before_each='', after_each='') }}</span>
+          </a>
+        {% else %}
+          <a href="/alerts/mobile-network-operator-tests" class="govuk-link govuk-body">
+            More information about mobile network operator tests
           </a>
         {% endif %}
       </div>

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -6,14 +6,14 @@
       <div class="alerts-icon__container alerts-icon__container--48">
         {{ alerts_icon(height=48, alert_active=alert.is_current) }}
         <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
-          {% if alert.message_type == 'operator' %}
+          {% if alert.channel == 'operator' %}
             Mobile network operator test
           {% else %}
             <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.area_names | formatted_list(before_each='', after_each='') }}
           {% endif %}
         </h2>
         {{ alert.description | paragraphize }}
-        {% if alert.message_type == 'operator' %}
+        {% if alert.channel == 'operator' %}
           <a href="/alerts/mobile-network-operator-tests" class="govuk-link govuk-body">
             More information about mobile network operator tests
           </a>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 import pytz
+from bs4 import BeautifulSoup
 
 from build import setup_jinja_environment
 from lib.alerts import Alerts
@@ -9,7 +10,9 @@ from lib.alerts import Alerts
 
 @pytest.fixture()
 def env():
-    return setup_jinja_environment(Alerts([]))
+    test_env = setup_jinja_environment(Alerts([]))
+    test_env.filters['file_fingerprint'] = lambda path: path
+    return test_env
 
 
 @pytest.fixture()
@@ -25,3 +28,9 @@ def alert_dict():
         'sent': datetime(2021, 4, 21, 11, 30, tzinfo=pytz.utc),
         'expires': datetime(2021, 4, 21, 12, 30, tzinfo=pytz.utc)
     }
+
+
+def render_template(env, template_path, template_vars={}):
+    template = env.get_template(template_path)
+    content = template.render(template_vars)
+    return BeautifulSoup(content, 'html.parser')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,12 @@ import pytest
 import pytz
 
 from build import setup_jinja_environment
+from lib.alerts import Alerts
 
 
 @pytest.fixture()
 def env():
-    return setup_jinja_environment([])
+    return setup_jinja_environment(Alerts([]))
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def alert_dict():
         'headline': 'Emergency alert',
         'description': 'Something',
         'area_names': [],
-        'message_type': 'alert',
+        'channel': 'severe',
         'identifier': '1234',
         'static_map_png': 'a-file.png',
         'starts': datetime(2021, 4, 21, 11, 25, tzinfo=pytz.utc),

--- a/tests/lib/test_alert.py
+++ b/tests/lib/test_alert.py
@@ -86,10 +86,11 @@ def test_is_current_and_public(is_current, is_public, is_current_and_public, moc
     assert Alert(alert_dict).is_current_and_public == is_current_and_public
 
 
-@pytest.mark.parametrize('message_type,is_public', [
-    ['alert', True],
+@pytest.mark.parametrize('channel,is_public', [
+    ['severe', True],
+    ['government', True],
     ['operator', False]
 ])
-def test_is_public(message_type, is_public, alert_dict):
-    alert_dict['message_type'] = message_type
+def test_is_public(channel, is_public, alert_dict):
+    alert_dict['channel'] = channel
     assert Alert(alert_dict).is_public == is_public

--- a/tests/lib/test_alert.py
+++ b/tests/lib/test_alert.py
@@ -62,18 +62,6 @@ def test_is_current_alert_checks_if_alert_is_current(
     assert Alert(alert_dict).is_current == is_current
 
 
-@pytest.mark.parametrize('is_expired,is_public,is_expired_or_test', [
-    [True, True, True],
-    [False, True, False],
-    [True, False, True],
-    [False, False, True]
-])
-def test_is_expired_or_test(is_expired, is_public, is_expired_or_test, mocker, alert_dict):
-    mocker.patch(__name__ + '.Alert.is_expired', is_expired)
-    mocker.patch(__name__ + '.Alert.is_public', is_public)
-    assert Alert(alert_dict).is_expired_or_test == is_expired_or_test
-
-
 @pytest.mark.parametrize('is_current,is_public,is_current_and_public', [
     [True, True, True],
     [False, True, False],

--- a/tests/lib/test_alert.py
+++ b/tests/lib/test_alert.py
@@ -60,3 +60,36 @@ def test_is_current_alert_checks_if_alert_is_current(
     alert_dict['sent'] = sent_date
     alert_dict['expires'] = expiry_date
     assert Alert(alert_dict).is_current == is_current
+
+
+@pytest.mark.parametrize('is_expired,is_public,is_expired_or_test', [
+    [True, True, True],
+    [False, True, False],
+    [True, False, True],
+    [False, False, True]
+])
+def test_is_expired_or_test(is_expired, is_public, is_expired_or_test, mocker, alert_dict):
+    mocker.patch(__name__ + '.Alert.is_expired', is_expired)
+    mocker.patch(__name__ + '.Alert.is_public', is_public)
+    assert Alert(alert_dict).is_expired_or_test == is_expired_or_test
+
+
+@pytest.mark.parametrize('is_current,is_public,is_current_and_public', [
+    [True, True, True],
+    [False, True, False],
+    [True, False, False],
+    [False, False, False]
+])
+def test_is_current_and_public(is_current, is_public, is_current_and_public, mocker, alert_dict):
+    mocker.patch(__name__ + '.Alert.is_current', is_current)
+    mocker.patch(__name__ + '.Alert.is_public', is_public)
+    assert Alert(alert_dict).is_current_and_public == is_current_and_public
+
+
+@pytest.mark.parametrize('message_type,is_public', [
+    ['alert', True],
+    ['operator', False]
+])
+def test_is_public(message_type, is_public, alert_dict):
+    alert_dict['message_type'] = message_type
+    assert Alert(alert_dict).is_public == is_public

--- a/tests/lib/test_alerts.py
+++ b/tests/lib/test_alerts.py
@@ -65,3 +65,11 @@ def test_expired_or_test_alerts(alert_dict, mocker):
 
     mocker.patch(__name__ + '.Alert.is_expired_or_test', False)
     assert len(Alerts([alert_dict]).expired_or_test) == 0
+
+
+def test_public_alerts(alert_dict, mocker):
+    mocker.patch(__name__ + '.Alert.is_public', True)
+    assert len(Alerts([alert_dict]).public) == 1
+
+    mocker.patch(__name__ + '.Alert.is_public', False)
+    assert len(Alerts([alert_dict]).public) == 0

--- a/tests/lib/test_alerts.py
+++ b/tests/lib/test_alerts.py
@@ -59,12 +59,12 @@ def test_current_and_public_alerts(alert_dict, mocker):
     assert len(Alerts([alert_dict]).current_and_public) == 0
 
 
-def test_expired_or_test_alerts(alert_dict, mocker):
-    mocker.patch(__name__ + '.Alert.is_expired_or_test', True)
-    assert len(Alerts([alert_dict]).expired_or_test) == 1
+def test_expired_alerts(alert_dict, mocker):
+    mocker.patch(__name__ + '.Alert.is_expired', True)
+    assert len(Alerts([alert_dict]).expired) == 1
 
-    mocker.patch(__name__ + '.Alert.is_expired_or_test', False)
-    assert len(Alerts([alert_dict]).expired_or_test) == 0
+    mocker.patch(__name__ + '.Alert.is_expired', False)
+    assert len(Alerts([alert_dict]).expired) == 0
 
 
 def test_public_alerts(alert_dict, mocker):

--- a/tests/src/test_alert.py
+++ b/tests/src/test_alert.py
@@ -1,0 +1,20 @@
+import pytest
+
+from lib.alert import Alert
+from tests.conftest import render_template
+
+
+@pytest.mark.parametrize('is_expired_or_test,breadcrumb', [
+    [True, 'Past alerts'],
+    [False, 'Current alerts']
+])
+def test_alert_breadcrumbs(
+    is_expired_or_test,
+    breadcrumb,
+    env,
+    alert_dict,
+    mocker,
+):
+    mocker.patch(__name__ + '.Alert.is_expired_or_test', is_expired_or_test)
+    html = render_template(env, 'src/alert.html', {'alert_data': Alert(alert_dict)})
+    assert html.select('.govuk-breadcrumbs__link')[2].text == breadcrumb

--- a/tests/src/test_alert.py
+++ b/tests/src/test_alert.py
@@ -4,17 +4,17 @@ from lib.alert import Alert
 from tests.conftest import render_template
 
 
-@pytest.mark.parametrize('is_expired_or_test,breadcrumb', [
+@pytest.mark.parametrize('is_expired,breadcrumb', [
     [True, 'Past alerts'],
     [False, 'Current alerts']
 ])
 def test_alert_breadcrumbs(
-    is_expired_or_test,
+    is_expired,
     breadcrumb,
     env,
     alert_dict,
     mocker,
 ):
-    mocker.patch(__name__ + '.Alert.is_expired_or_test', is_expired_or_test)
+    mocker.patch(__name__ + '.Alert.is_expired', is_expired)
     html = render_template(env, 'src/alert.html', {'alert_data': Alert(alert_dict)})
     assert html.select('.govuk-breadcrumbs__link')[2].text == breadcrumb

--- a/tests/src/test_current_alerts.py
+++ b/tests/src/test_current_alerts.py
@@ -1,8 +1,22 @@
 from bs4 import BeautifulSoup
 
+from lib.alert import Alert
+
 
 def test_current_alerts_page(env):
     template = env.get_template("src/current-alerts.html")
     content = template.render()
     html = BeautifulSoup(content, 'html.parser')
     assert html.select_one('h1').text.strip() == "Current alerts"
+
+
+def test_current_alerts_page_shows_alerts(
+    alert_dict,
+    env,
+    mocker,
+):
+    mocker.patch('lib.alerts.Alerts.current_public', [Alert(alert_dict)])
+    template = env.get_template("src/current-alerts.html")
+    content = template.render()
+    html = BeautifulSoup(content, 'html.parser')
+    assert len(html.select('h2.alerts-alert__title')) == 1

--- a/tests/src/test_current_alerts.py
+++ b/tests/src/test_current_alerts.py
@@ -12,6 +12,13 @@ def test_current_alerts_page_shows_alerts(
     env,
     mocker,
 ):
-    mocker.patch('lib.alerts.Alerts.current_public', [Alert(alert_dict)])
+    alert_dict['area_names'] = ['foo']
+    mocker.patch('lib.alerts.Alerts.current_and_public', [Alert(alert_dict)])
+
     html = render_template(env, "src/current-alerts.html")
-    assert len(html.select('h2.alerts-alert__title')) == 1
+    titles = html.select('h2.alerts-alert__title')
+    link = html.select_one('a.govuk-body')
+
+    assert len(titles) == 1
+    assert titles[0].text.strip() == 'Emergency alert sent to foo'
+    assert 'More information about this alert' in link.text

--- a/tests/src/test_current_alerts.py
+++ b/tests/src/test_current_alerts.py
@@ -1,12 +1,9 @@
-from bs4 import BeautifulSoup
-
 from lib.alert import Alert
+from tests.conftest import render_template
 
 
 def test_current_alerts_page(env):
-    template = env.get_template("src/current-alerts.html")
-    content = template.render()
-    html = BeautifulSoup(content, 'html.parser')
+    html = render_template(env, "src/current-alerts.html")
     assert html.select_one('h1').text.strip() == "Current alerts"
 
 
@@ -16,7 +13,5 @@ def test_current_alerts_page_shows_alerts(
     mocker,
 ):
     mocker.patch('lib.alerts.Alerts.current_public', [Alert(alert_dict)])
-    template = env.get_template("src/current-alerts.html")
-    content = template.render()
-    html = BeautifulSoup(content, 'html.parser')
+    html = render_template(env, "src/current-alerts.html")
     assert len(html.select('h2.alerts-alert__title')) == 1

--- a/tests/src/test_index.py
+++ b/tests/src/test_index.py
@@ -1,8 +1,6 @@
-from bs4 import BeautifulSoup
+from tests.conftest import render_template
 
 
 def test_index_page(env):
-    template = env.get_template("src/index.html")
-    content = template.render()
-    html = BeautifulSoup(content, 'html.parser')
+    html = render_template(env, "src/index.html")
     assert html.select_one('h1').text.strip() == "Emergency Alerts"

--- a/tests/src/test_past_alerts.py
+++ b/tests/src/test_past_alerts.py
@@ -1,12 +1,9 @@
-from bs4 import BeautifulSoup
-
 from lib.alert import Alert
+from tests.conftest import render_template
 
 
 def test_past_alerts_page(env):
-    template = env.get_template("src/past-alerts.html")
-    content = template.render()
-    html = BeautifulSoup(content, 'html.parser')
+    html = render_template(env, "src/past-alerts.html")
     assert html.select_one('h1').text.strip() == "Past alerts"
 
 
@@ -16,7 +13,5 @@ def test_past_alerts_page_shows_alerts(
     env
 ):
     mocker.patch('lib.alerts.Alerts.expired_or_test', [Alert(alert_dict)])
-    template = env.get_template("src/past-alerts.html")
-    content = template.render()
-    html = BeautifulSoup(content, 'html.parser')
+    html = render_template(env, "src/past-alerts.html")
     assert len(html.select('h2.alerts-alert__title')) == 1

--- a/tests/src/test_past_alerts.py
+++ b/tests/src/test_past_alerts.py
@@ -1,8 +1,22 @@
 from bs4 import BeautifulSoup
 
+from lib.alert import Alert
+
 
 def test_past_alerts_page(env):
     template = env.get_template("src/past-alerts.html")
     content = template.render()
     html = BeautifulSoup(content, 'html.parser')
     assert html.select_one('h1').text.strip() == "Past alerts"
+
+
+def test_past_alerts_page_shows_alerts(
+    mocker,
+    alert_dict,
+    env
+):
+    mocker.patch('lib.alerts.Alerts.expired_or_test', [Alert(alert_dict)])
+    template = env.get_template("src/past-alerts.html")
+    content = template.render()
+    html = BeautifulSoup(content, 'html.parser')
+    assert len(html.select('h2.alerts-alert__title')) == 1

--- a/tests/src/test_past_alerts.py
+++ b/tests/src/test_past_alerts.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lib.alert import Alert
 from tests.conftest import render_template
 
@@ -7,11 +9,34 @@ def test_past_alerts_page(env):
     assert html.select_one('h1').text.strip() == "Past alerts"
 
 
+@pytest.mark.parametrize('channel,expected_title,expected_link_text', [
+    [
+        'operator',
+        'Mobile network operator test',
+        'More information about mobile network operator tests',
+    ],
+    [
+        'severe',
+        'Emergency alert sent to foo',
+        'More information about this alert',
+    ]
+])
 def test_past_alerts_page_shows_alerts(
+    channel,
+    expected_title,
+    expected_link_text,
     mocker,
     alert_dict,
     env
 ):
+    alert_dict['channel'] = channel
+    alert_dict['area_names'] = ['foo']
     mocker.patch('lib.alerts.Alerts.expired_or_test', [Alert(alert_dict)])
+
     html = render_template(env, "src/past-alerts.html")
-    assert len(html.select('h2.alerts-alert__title')) == 1
+    titles = html.select('h2.alerts-alert__title')
+    link = html.select_one('a.govuk-body')
+
+    assert len(titles) == 1
+    assert titles[0].text.strip() == expected_title
+    assert expected_link_text in link.text

--- a/tests/src/test_past_alerts.py
+++ b/tests/src/test_past_alerts.py
@@ -9,28 +9,28 @@ def test_past_alerts_page(env):
     assert html.select_one('h1').text.strip() == "Past alerts"
 
 
-@pytest.mark.parametrize('channel,expected_title,expected_link_text', [
+@pytest.mark.parametrize('is_public,expected_title,expected_link_text', [
     [
-        'operator',
+        False,
         'Mobile network operator test',
         'More information about mobile network operator tests',
     ],
     [
-        'severe',
+        True,
         'Emergency alert sent to foo',
         'More information about this alert',
     ]
 ])
 def test_past_alerts_page_shows_alerts(
-    channel,
+    is_public,
     expected_title,
     expected_link_text,
     mocker,
     alert_dict,
     env
 ):
-    alert_dict['channel'] = channel
     alert_dict['area_names'] = ['foo']
+    mocker.patch('lib.alert.Alert.is_public', is_public)
     mocker.patch('lib.alerts.Alerts.expired_or_test', [Alert(alert_dict)])
 
     html = render_template(env, "src/past-alerts.html")

--- a/tests/src/test_past_alerts.py
+++ b/tests/src/test_past_alerts.py
@@ -31,7 +31,7 @@ def test_past_alerts_page_shows_alerts(
 ):
     alert_dict['area_names'] = ['foo']
     mocker.patch('lib.alert.Alert.is_public', is_public)
-    mocker.patch('lib.alerts.Alerts.expired_or_test', [Alert(alert_dict)])
+    mocker.patch('lib.alerts.Alerts.expired', [Alert(alert_dict)])
 
     html = render_template(env, "src/past-alerts.html")
     titles = html.select('h2.alerts-alert__title')

--- a/tests/test_content_security_policy_sha.py
+++ b/tests/test_content_security_policy_sha.py
@@ -1,18 +1,13 @@
 import base64
 import hashlib
 
-from bs4 import BeautifulSoup
-
-from tests.src import env
+from tests.conftest import render_template
 
 
-def test_content_security_policy_sha():
+def test_content_security_policy_sha(env):
     script_sha256_base64_encoded = b"+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU="
-    env.filters['file_fingerprint'] = lambda path: path  # stub out filters
 
-    template = env.get_template('src/index.html')
-    content = template.render()
-    html = BeautifulSoup(content, 'html.parser')
+    html = render_template(env, 'src/index.html')
     inline_script = html.select_one('body > script')
 
     assert inline_script is not None


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178774818

This is part of the work we need to do to replace (most of) the data.yaml
file with an API. Please see the commit messages for more details.

One outstanding question is whether we should ever show messages on the test
channel. Currently we don't have any, but if we did they would appear like any
other alert. We don't need to answer this question here, and I've made a note
on the card to make a decision as part of writing the API.