### PR TITLE
Rename demo area to match Admin app

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -93,7 +93,7 @@ alerts:
 
       To find out more, call 0808 1697692 or search for gov.uk/alerts
     area_names:
-      - Leiston in East Suffolk
+      - East Suffolk
   - identifier: 3-may-2021
     channel: severe
     approved_at: 2021-05-25T13:00:14+01:00
@@ -107,4 +107,4 @@ alerts:
 
       To find out more, call 0808 1697692 or search for gov.uk/alerts
     area_names:
-      - Leiston in East Suffolk
+      - East Suffolk


### PR DESCRIPTION
The Admin app has a standalone "Sizewell" area for this alert. We
decided to change both apps to just say "East Suffolk", to match
the level of precision we expect to have for standard areas [1],
but still customising it for the alert.

[1]: https://github.com/alphagov/notifications-admin/pull/3980