### PR TITLE
Add 5 August planned operator test to alerts page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -42,6 +42,9 @@
   {% if alerts.current_and_public %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
+  {% else %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  {{ planned_tests_banner(1, 'Thursday 5 August 2021') }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/src/planned-tests.html
+++ b/src/planned-tests.html
@@ -38,9 +38,8 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
-      {#
       <h2 class="govuk-heading-m govuk-!-margin-top-6">
-        [day of week] [day of month] [month] [year]
+        Thursday 5 August 2021
       </h2>
       <p class="govuk-body">
         Some mobile phone networks in the UK will test emergency alerts between 1pm and 2pm.
@@ -59,13 +58,14 @@
           This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
         </p>
       </div>
-      #}
+      {#
       <p class="govuk-body">
         There are currently no planned tests of emergency alerts.
       </p>
       <p class="govuk-body">
         You can see previous tests on the <a class="govuk-link" href="/alerts/past-alerts">past alerts page</a>.
       </p>
+      #}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
### Context

O2 are performing resilience tests requiring messages to be sent on the operator channel to public cells on the live network.

This change updates current alerts to display information about the tests.