### PR TITLE
Add explainer film to the homepage

### DIFF
--- a/src/assets/stylesheets/components/responsive-embed.scss
+++ b/src/assets/stylesheets/components/responsive-embed.scss
@@ -1,0 +1,66 @@
+@import "govuk/settings/all";
+@import "govuk/helpers/all";
+
+// Responsive Embed Component
+//
+//   Notes:
+//
+//   - Ensure you use either responsive-embed--16by9 or responsive-embed--4by3
+//     depending on the aspect ratio of your embed.
+//   - Credit: Nicolas Gallagher and SUIT CSS.
+//
+//   Example Usage:
+//
+//   <div class="responsive-embed responsive-embed--4by3 responsive-embed--bordered">
+//     <div class="responsive-embed__wrapper">
+//       <iframe width="560" height="315" src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" frameborder="0" allowfullscreen=""></iframe>
+//     </div>
+//   </div>
+
+.responsive-embed {
+
+  margin-top: govuk-spacing(6);
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(1);
+    margin-bottom: 0;
+  }
+
+  .responsive-embed__wrapper {
+    position: relative;
+    display: block;
+    height: 0;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .responsive-embed__item,
+  iframe,
+  embed,
+  object,
+  video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: 100%;
+    width: 100%;
+    border: 0;
+  }
+}
+
+// Modifier class for 16:9 aspect ratio
+.responsive-embed--16by9 {
+  .responsive-embed__wrapper {
+    padding-bottom: 56.25%;
+  }
+}
+
+// Modifier class for 4:3 aspect ratio – uncomment if needed
+//
+//.responsive-embed--4by3 {
+//  .responsive-embed__wrapper {
+//    padding-bottom: 75%;
+//  }
+//}

--- a/src/assets/stylesheets/components/responsive-embed.scss
+++ b/src/assets/stylesheets/components/responsive-embed.scss
@@ -27,7 +27,7 @@
     margin-bottom: 0;
   }
 
-  .responsive-embed__wrapper {
+  .responsive-embed__content {
     position: relative;
     display: block;
     height: 0;

--- a/src/assets/stylesheets/main.scss
+++ b/src/assets/stylesheets/main.scss
@@ -4,5 +4,6 @@
 @import "components/image";
 @import "components/alert";
 @import "components/example";
+@import "components/responsive-embed";
 @import "globals";
 @import "extensions";

--- a/src/index.html
+++ b/src/index.html
@@ -102,6 +102,13 @@
         <a href="/alerts/how-alerts-work" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">How emergency alerts work</a>
       </p>
     </div>
+    <div class="govuk-grid-column-one-half">
+      <div class="responsive-embed responsive-embed--16by9">
+        <div class="responsive-embed__wrapper">
+          <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/9yLd2AjGzYI" frameborder="0" allowfullscreen></iframe>
+        </div>
+      </div>
+    </div>
   </div>
 {% endblock %}
 

--- a/src/index.html
+++ b/src/index.html
@@ -104,7 +104,7 @@
     </div>
     <div class="govuk-grid-column-one-half">
       <div class="responsive-embed responsive-embed--16by9">
-        <div class="responsive-embed__wrapper">
+        <div class="responsive-embed__content">
           <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/9yLd2AjGzYI" frameborder="0" allowfullscreen></iframe>
         </div>
       </div>


### PR DESCRIPTION
We’ve agreed with the comms folk that this video should go in the empty space on the homepage.

I’ve borrowed the responsive embed CSS from the admin app to make sure the video displays properly on different device sizes.

Hosted on Youtube, but served via their cookie-free domain so we don’t need to add a cookie policy.

![image](https://user-images.githubusercontent.com/355079/129186762-2b7e663e-0909-4e72-9b1d-5c3a3f6917de.png)

![image](https://user-images.githubusercontent.com/355079/129186812-645f1c75-199c-4f80-bb0b-4d0637aedff3.png)

***

https://www.youtube.com/watch?v=9yLd2AjGzYI