### PR TITLE
Rename all references to responsive embed wrapper

### DIFF
--- a/src/assets/stylesheets/components/responsive-embed.scss
+++ b/src/assets/stylesheets/components/responsive-embed.scss
@@ -52,7 +52,7 @@
 
 // Modifier class for 16:9 aspect ratio
 .responsive-embed--16by9 {
-  .responsive-embed__wrapper {
+  .responsive-embed__content {
     padding-bottom: 56.25%;
   }
 }
@@ -60,7 +60,7 @@
 // Modifier class for 4:3 aspect ratio – uncomment if needed
 //
 //.responsive-embed--4by3 {
-//  .responsive-embed__wrapper {
+//  .responsive-embed__content {
 //    padding-bottom: 75%;
 //  }
 //}


### PR DESCRIPTION
Responsive embed _wrapper_ was renamed to _content_ in e1f0e13. Some references were missed causing minor style issues and 0 iframe content height.

**Before**

<img width="524" alt="Screenshot 2021-08-16 at 14 34 44" src="https://user-images.githubusercontent.com/783245/129572208-81074f54-b722-4c00-a138-4b769877a5e2.png">

**After**
<img width="573" alt="Screenshot 2021-08-16 at 14 35 20" src="https://user-images.githubusercontent.com/783245/129572393-dad2f384-7c5f-4891-93f4-ff6ba550e92e.png">
