### PR TITLE
Fix Celery worker crashing after deployment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,7 +29,7 @@ class Config():
             'wait_time_seconds': 20,  # enable long polling, with a wait time of 20 seconds
         },
         'timezone': 'Europe/London',
-        'imports': ['main'],
+        'imports': ['app.celery.tasks'],
         'task_queues': [
             Queue(QUEUE_NAME, Exchange('default'), routing_key=QUEUE_NAME)
         ],

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -11,7 +11,7 @@ applications:
 
     processes:
     - type: web
-      command: celery -A main.notify_celery worker --loglevel=INFO --concurrency=1 2> /dev/null
+      command: celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=1 2> /dev/null
 
       health-check-type: process
       memory: 2G


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178801234

Resolves: https://github.com/alphagov/notifications-govuk-alerts/pull/151#discussion_r688341788

This is firstly because the startup command referred to a package
('main') that didn't exist, which we also then tried to import.