### PR TITLE
Add command / task to republish alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ cf-deploy: cf-target ## Deploys the app to Cloud Foundry
 	# delete old manifest file
 	rm -f ${CF_MANIFEST_PATH}
 
+cf-run-task-publish: cf-target
+	cf run-task notify-govuk-alerts -c 'flask publish'
+
 .PHONY: staging
 staging: ## Set environment to staging
 	$(eval export DEPLOY_ENV=staging)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,6 +20,9 @@ def create_app():
     from app import config
     application.config.from_object(config.Config)
 
+    from app.commands import setup_commands
+    setup_commands(application)
+
     statsd_client.init_app(application)
     logging.init_app(application, statsd_client)
     notify_celery.init_app(application)

--- a/app/commands.py
+++ b/app/commands.py
@@ -1,0 +1,12 @@
+import click
+
+from app.celery.tasks import publish_govuk_alerts
+
+
+def setup_commands(app):
+    app.cli.add_command(publish)
+
+
+@click.command('publish')
+def publish():
+    publish_govuk_alerts()

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -1,0 +1,6 @@
+def test_publish(mocker, govuk_alerts):
+    publish_mock = mocker.patch('app.commands.publish_govuk_alerts')
+    runner = govuk_alerts.test_cli_runner()
+
+    runner.invoke(args=['publish'])
+    publish_mock.assert_called_once()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178801234

This is intended to be run straight after a deployment. A downside
of 'cf run-task' is that it's asynchronous, so just like a normal
app crashing, we'll need to have some other alerting in place so
we learn if the publish task failed.