### PR TITLE
Simplify aggregate area names to be part of areas

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -8,7 +8,6 @@ alerts:
     content: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     areas: {}
-    general_area_names:
   - identifier:
     channel: operator
     approved_at: 2021-07-16T13:00:27+01:00
@@ -18,7 +17,6 @@ alerts:
     content: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     areas: {}
-    general_area_names:
   - identifier:
     channel: operator
     approved_at: 2021-07-14T13:00:18+01:00
@@ -28,7 +26,6 @@ alerts:
     content: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     areas: {}
-    general_area_names:
   - identifier:
     channel: operator
     approved_at: 2021-07-09T12:58:58+01:00
@@ -38,7 +35,6 @@ alerts:
     content: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     areas: {}
-    general_area_names:
 ### vvv DO NOT DELETE: NOT IN DB vvv ###
   - identifier:
     channel: operator
@@ -49,7 +45,6 @@ alerts:
     content: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     areas: {}
-    general_area_names:
 ### ^^^ DO NOT DELETE: NOT IN DB ^^^ ###
   - identifier: 29-june-2021
     channel: severe
@@ -63,9 +58,9 @@ alerts:
       Emergency alerts tell you what to do if there’s a life-threatening event nearby.
 
       To find out more, call 0808 1697692 or search for gov.uk/alerts
-    areas: {}
-    general_area_names:
-      - Reading, Berkshire
+    areas:
+      aggregate_names:
+        - Reading, Berkshire
 ### vvv DO NOT DELETE: NOT IN DB vvv ###
   - identifier:
     channel: operator
@@ -86,7 +81,6 @@ alerts:
     content: |
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     areas: {}
-    general_area_names:
 ### ^^^ DO NOT DELETE: NOT IN DB ^^^ ###
   - identifier: 25-may-2021-2
     channel: government
@@ -100,9 +94,9 @@ alerts:
       Emergency alerts tell you what to do if there’s a life-threatening event nearby.
 
       To find out more, call 0808 1697692 or search for gov.uk/alerts
-    areas: {}
-    general_area_names:
-      - East Suffolk
+    areas:
+      aggregate_names:
+        - East Suffolk
   - identifier: 3-may-2021
     channel: severe
     approved_at: 2021-05-25T13:00:14+01:00
@@ -117,5 +111,5 @@ alerts:
       To find out more, call 0808 1697692 or search for gov.uk/alerts
     areas:
       simple_polygons: [[[52.22035, 1.58242], [52.19521, 1.58491], [52.19325, 1.59971], [52.19372, 1.62352], [52.21901, 1.62599], [52.22035, 1.58242]]]
-    general_area_names:
-      - East Suffolk
+      aggregate_names:
+        - East Suffolk

--- a/lib/alert.py
+++ b/lib/alert.py
@@ -16,7 +16,6 @@ class Alert(SerialisedModel):
         'finishes_at',
         'content',
         'areas',
-        'general_area_names',
     }
 
     def __lt__(self, other):

--- a/src/alert.html
+++ b/src/alert.html
@@ -8,7 +8,7 @@
 {%- from "templates/components/meta_tags.html" import metaTags -%}
 
 {% set pageTitle = "Emergency alert" %}
-{% set alertAreaNames = alert_data.general_area_names | formatted_list(before_each='', after_each='') %}
+{% set alertAreaNames = alert_data.areas.aggregate_names | formatted_list(before_each='', after_each='') %}
 
 {% block metaTags %}
   {{ metaTags(

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -7,7 +7,7 @@
         {{ alerts_icon(height=48, alert_active=alert.is_current) }}
         <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
           {% if alert.is_public %}
-            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.general_area_names | formatted_list(before_each='', after_each='') }}
+            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.areas.aggregate_names | formatted_list(before_each='', after_each='') }}
           {% else %}
             Mobile network operator test
           {% endif %}
@@ -16,7 +16,7 @@
         {% if alert.is_public %}
           <a href="/alerts/{{ alert.identifier }}" class="govuk-link govuk-body">
             More information about this alert
-            <span class="govuk-visually-hidden">to {{ alert.general_area_names | formatted_list(before_each='', after_each='') }}</span>
+            <span class="govuk-visually-hidden">to {{ alert.areas.aggregate_names | formatted_list(before_each='', after_each='') }}</span>
           </a>
         {% else %}
           <a href="/alerts/mobile-network-operator-tests" class="govuk-link govuk-body">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ def alert_dict():
     return {
         'headline': 'Emergency alert',
         'content': 'Something',
-        'general_area_names': [],
         'areas': dict(),
         'channel': 'severe',
         'identifier': '1234',

--- a/tests/src/test_current_alerts.py
+++ b/tests/src/test_current_alerts.py
@@ -12,7 +12,7 @@ def test_current_alerts_page_shows_alerts(
     env,
     mocker,
 ):
-    alert_dict['general_area_names'] = ['foo']
+    alert_dict['areas']['aggregate_names'] = ['foo']
     mocker.patch('lib.alerts.Alerts.current_and_public', [Alert(alert_dict)])
 
     html = render_template(env, "src/current-alerts.html")

--- a/tests/src/test_past_alerts.py
+++ b/tests/src/test_past_alerts.py
@@ -29,7 +29,7 @@ def test_past_alerts_page_shows_alerts(
     alert_dict,
     env
 ):
-    alert_dict['general_area_names'] = ['foo']
+    alert_dict['areas']['aggregate_names'] = ['foo']
     mocker.patch('lib.alert.Alert.is_public', is_public)
     mocker.patch('lib.alerts.Alerts.expired', [Alert(alert_dict)])
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178986763

Previously this was a separate list due to some confusion about the
"areas" field being a list (of lists). In reality it's just a dict
with a "simple_polygons" field, so we can co-locate aggregate area
names inside it as another field.