### PR TITLE
Support aggregate areas with granular fallback

### DIFF
--- a/app/models/alert.py
+++ b/app/models/alert.py
@@ -22,6 +22,13 @@ class Alert(SerialisedModel):
         return self.starts_at < other.starts_at
 
     @property
+    def display_areas(self):
+        if "aggregate_names" in self.areas:
+            return self.areas["aggregate_names"]
+
+        return self.areas.get("names", [])
+
+    @property
     def starts_at_date(self):
         return AlertDate(self.starts_at)
 

--- a/app/templates/components/alert.html
+++ b/app/templates/components/alert.html
@@ -7,7 +7,7 @@
         {{ alerts_icon(height=48, alert_active=alert.is_current) }}
         <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
           {% if alert.is_public %}
-            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.areas.aggregate_names | formatted_list(before_each='', after_each='') }}
+            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') }}
           {% else %}
             Mobile network operator test
           {% endif %}
@@ -16,7 +16,7 @@
         {% if alert.is_public %}
           <a href="/alerts/{{ alert.identifier }}" class="govuk-link govuk-body">
             More information about this alert
-            <span class="govuk-visually-hidden">to {{ alert.areas.aggregate_names | formatted_list(before_each='', after_each='') }}</span>
+            <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') }}</span>
           </a>
         {% else %}
           <a href="/alerts/mobile-network-operator-tests" class="govuk-link govuk-body">

--- a/app/templates/views/alert.html
+++ b/app/templates/views/alert.html
@@ -8,7 +8,7 @@
 {%- from "components/meta_tags.html" import metaTags -%}
 
 {% set pageTitle = "Emergency alert" %}
-{% set alertAreaNames = alert_data.areas.aggregate_names | formatted_list(before_each='', after_each='') %}
+{% set alertAreaNames = alert_data.display_areas | formatted_list(before_each='', after_each='') %}
 
 {% block metaTags %}
   {{ metaTags(

--- a/tests/app/main/views/test_current_alerts.py
+++ b/tests/app/main/views/test_current_alerts.py
@@ -11,7 +11,7 @@ def test_current_alerts_page_shows_alerts(
     client_get,
     mocker,
 ):
-    alert_dict['areas']['aggregate_names'] = ['foo']
+    mocker.patch('app.models.alert.Alert.display_areas', ['foo'])
     mocker.patch('app.models.alerts.Alerts.current_and_public', [Alert(alert_dict)])
 
     html = client_get("alerts/current-alerts")

--- a/tests/app/main/views/test_past_alerts.py
+++ b/tests/app/main/views/test_past_alerts.py
@@ -28,7 +28,7 @@ def test_past_alerts_page_shows_alerts(
     alert_dict,
     client_get
 ):
-    alert_dict['areas']['aggregate_names'] = ['foo']
+    mocker.patch('app.models.alert.Alert.display_areas', ['foo'])
     mocker.patch('app.models.alert.Alert.is_public', is_public)
     mocker.patch('app.models.alerts.Alerts.expired', [Alert(alert_dict)])
 

--- a/tests/app/models/test_alert.py
+++ b/tests/app/models/test_alert.py
@@ -26,6 +26,19 @@ def test_lt_compares_alerts_based_on_start_date(alert_dict):
     assert Alert(alert_dict_1) < Alert(alert_dict_2)
 
 
+def test_display_areas_falls_back_to_granular_names(alert_dict):
+    alert_dict['areas']['aggregate_names'] = ['aggregate name']
+    alert_dict['areas']['names'] = ['granular name']
+
+    assert Alert(alert_dict).display_areas == ['aggregate name']
+
+    del alert_dict['areas']['aggregate_names']
+    assert Alert(alert_dict).display_areas == ['granular name']
+
+    del alert_dict['areas']['names']
+    assert Alert(alert_dict).display_areas == []
+
+
 def test_expires_date_returns_earliest_expiry_time(alert_dict):
     alert = Alert(alert_dict)
     assert alert.expires_date.as_iso8601 == alert.cancelled_at_date.as_iso8601


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178986763

In the Admin app we plan to calculate and store "aggregate_names"
[1], but broadcasts created via the API may just have "names" [2]
that may well be understandable for display purpose (we can't tell
in advance). This change means we support both.

[1]: https://github.com/alphagov/notifications-admin/pull/4003
[2]: https://github.com/alphagov/notifications-api/pull/3312/files#diff-9999ef738a93db421762e26ea37b640815222146e1c02a4f58e8d53a7e4230baR73