### PR TITLE
Improve grouping of past alerts

### DIFF
--- a/app/models/alert_date.py
+++ b/app/models/alert_date.py
@@ -39,3 +39,7 @@ class AlertDate(object):
     @property
     def as_local_datetime(self):
         return self._local_datetime
+
+    @property
+    def as_local_date(self):
+        return self._local_datetime.date()

--- a/app/models/alerts.py
+++ b/app/models/alerts.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import yaml
 from notifications_utils.serialised_model import SerialisedModelCollection
 
@@ -16,6 +18,13 @@ class Alerts(SerialisedModelCollection):
     @property
     def expired(self):
         return [alert for alert in self if alert.is_expired]
+
+    @property
+    def expired_grouped_by_date(self):
+        alerts_by_date = defaultdict(list)
+        for alert in self.expired:
+            alerts_by_date[alert.starts_at_date.as_local_date].append(alert)
+        return alerts_by_date.items()
 
     @property
     def public(self):

--- a/app/models/alerts.py
+++ b/app/models/alerts.py
@@ -23,7 +23,11 @@ class Alerts(SerialisedModelCollection):
     def expired_grouped_by_date(self):
         alerts_by_date = defaultdict(list)
         for alert in self.expired:
-            alerts_by_date[alert.starts_at_date.as_local_date].append(alert)
+            if alert.is_public or all(
+                already_grouped_alert.is_public
+                for already_grouped_alert in alerts_by_date[alert.starts_at_date.as_local_date]
+            ):
+                alerts_by_date[alert.starts_at_date.as_local_date].append(alert)
         return alerts_by_date.items()
 
     @property

--- a/app/templates/components/alert.html
+++ b/app/templates/components/alert.html
@@ -1,17 +1,17 @@
 {%- from "components/alerts_icon.html" import alerts_icon -%}
 
-{% macro alert(alert) %}
+{% macro alert(alert, heading_level=2) %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="alerts-icon__container alerts-icon__container--48">
         {{ alerts_icon(height=48, alert_active=alert.is_current) }}
-        <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
+        <h{{ heading_level }} class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
           {% if alert.is_public %}
             <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') }}
           {% else %}
             Mobile network operator test
           {% endif %}
-        </h2>
+        </h{{ heading_level }}>
         {{ alert.content | paragraphize }}
         {% if alert.is_public %}
           <a href="/alerts/{{ alert.identifier }}" class="govuk-link govuk-body">

--- a/app/templates/views/past-alerts.html
+++ b/app/templates/views/past-alerts.html
@@ -41,17 +41,21 @@
   <h1 class="govuk-heading-xl">
     {{ pageTitle }}
   </h1>
-  {% for past_alert in alerts.expired | sort(reverse=True) %}
-  <h2 class="govuk-heading-m {% if not loop.first %}govuk-!-margin-top-9{% endif %}">
-    {{ past_alert.starts_at_date.date_as_lang }}
-  </h2>
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  {{ alert(alert=past_alert) }}
-  {% endfor %}
-
-  {% if alerts.expired %}
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  {% for _date, past_alerts in alerts.expired_grouped_by_date | sort(reverse=True) %}
+    {% set date_loop = loop %}
+    {% for past_alert in past_alerts | sort(reverse=True) %}
+      {% if loop.first %}
+        <h2 class="govuk-heading-m {% if not date_loop.first %}govuk-!-margin-top-9{% endif %}">
+          {{ past_alert.starts_at_date.date_as_lang }}
+        </h2>
+      {% endif %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {{ alert(alert=past_alert) }}
+    {% endfor %}
+    {% if loop.last %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    {% endif %}
   {% else %}
-  <p class="govuk-body">There are no past emergency alerts.</p>
-  {% endif %}
+    <p class="govuk-body">There are no past emergency alerts.</p>
+  {% endfor %}
 {% endblock %}

--- a/app/templates/views/past-alerts.html
+++ b/app/templates/views/past-alerts.html
@@ -50,7 +50,7 @@
         </h2>
       {% endif %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-      {{ alert(alert=past_alert) }}
+      {{ alert(alert=past_alert, heading_level=3) }}
     {% endfor %}
     {% if loop.last %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/tests/app/main/views/test_past_alerts.py
+++ b/tests/app/main/views/test_past_alerts.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 import pytest
+import pytz
 
 from app.models.alert import Alert
 
@@ -39,3 +42,37 @@ def test_past_alerts_page_shows_alerts(
     assert len(titles) == 1
     assert titles[0].text.strip() == expected_title
     assert expected_link_text in link.text
+
+
+def test_past_alerts_page_groups_by_date(
+    mocker,
+    alert_dict,
+    client_get,
+):
+    alert_dict_2 = alert_dict.copy()
+    alert_dict_3 = alert_dict.copy()
+
+    alert_dict_2['starts_at'] = datetime(2021, 4, 22, 0, 0, tzinfo=pytz.utc)
+    alert_dict_2['content'] = 'Something 2'
+
+    alert_dict_3['starts_at'] = datetime(2021, 4, 22, 22, 59, tzinfo=pytz.utc)
+    alert_dict_3['content'] = 'Something 3'
+
+    mocker.patch('app.models.alert.Alert.display_areas', ['foo'])
+    mocker.patch('app.models.alerts.Alerts.expired', [
+        Alert(alert_dict),
+        Alert(alert_dict_2),
+        Alert(alert_dict_3),
+    ])
+
+    html = client_get("alerts/past-alerts")
+    titles_and_paragraphs = html.select('main h2.govuk-heading-m, main p.govuk-body-l')
+    assert [
+        element.text.strip() for element in titles_and_paragraphs
+    ] == [
+        'Thursday 22 April 2021',
+        'Something 3',
+        'Something 2',
+        'Wednesday 21 April 2021',
+        'Something',
+    ]

--- a/tests/app/main/views/test_past_alerts.py
+++ b/tests/app/main/views/test_past_alerts.py
@@ -51,6 +51,7 @@ def test_past_alerts_page_groups_by_date(
 ):
     alert_dict_2 = alert_dict.copy()
     alert_dict_3 = alert_dict.copy()
+    alert_dict_4 = alert_dict.copy()
 
     alert_dict_2['starts_at'] = datetime(2021, 4, 22, 0, 0, tzinfo=pytz.utc)
     alert_dict_2['content'] = 'Something 2'
@@ -58,11 +59,17 @@ def test_past_alerts_page_groups_by_date(
     alert_dict_3['starts_at'] = datetime(2021, 4, 22, 22, 59, tzinfo=pytz.utc)
     alert_dict_3['content'] = 'Something 3'
 
+    alert_dict_4['channel'] = 'operator'
+    alert_dict_4['content'] = 'Operator test'
+
     mocker.patch('app.models.alert.Alert.display_areas', ['foo'])
     mocker.patch('app.models.alerts.Alerts.expired', [
         Alert(alert_dict),
+        Alert(alert_dict),
         Alert(alert_dict_2),
         Alert(alert_dict_3),
+        Alert(alert_dict_4),
+        Alert(alert_dict_4),
     ])
 
     html = client_get("alerts/past-alerts")
@@ -74,5 +81,9 @@ def test_past_alerts_page_groups_by_date(
         'Something 3',
         'Something 2',
         'Wednesday 21 April 2021',
+        # Multiple public alerts are shown individually
         'Something',
+        'Something',
+        # Multiple non-public alerts on the same day are combined into one
+        'Operator test',
     ]

--- a/tests/app/main/views/test_past_alerts.py
+++ b/tests/app/main/views/test_past_alerts.py
@@ -36,7 +36,7 @@ def test_past_alerts_page_shows_alerts(
     mocker.patch('app.models.alerts.Alerts.expired', [Alert(alert_dict)])
 
     html = client_get("alerts/past-alerts")
-    titles = html.select('h2.alerts-alert__title')
+    titles = html.select('h3.alerts-alert__title')
     link = html.select_one('a.govuk-body')
 
     assert len(titles) == 1


### PR DESCRIPTION
From this:

![image](https://user-images.githubusercontent.com/355079/131681295-0844721a-8368-49ce-a756-92cc876639a5.png)

***

To this (grouping the alerts by date heading):

![image](https://user-images.githubusercontent.com/355079/131681375-b6505e8f-b200-4e3a-a4e4-58012edd1c85.png)

***

To this (only showing one operator test per day):

![image](https://user-images.githubusercontent.com/355079/131681476-ffd9d2b7-2a75-40c0-8903-2903798d6d2b.png)
