### PR TITLE
Automate planned tests page

### DIFF
--- a/app/models/alert.py
+++ b/app/models/alert.py
@@ -6,15 +6,24 @@ from notifications_utils.serialised_model import SerialisedModel
 from app.models.alert_date import AlertDate
 
 
-class Alert(SerialisedModel):
+class BaseAlert(SerialisedModel):
     ALLOWED_PROPERTIES = {
+        'starts_at',
+        'content',
+    }
+
+    @property
+    def starts_at_date(self):
+        return AlertDate(self.starts_at)
+
+
+class Alert(BaseAlert):
+    ALLOWED_PROPERTIES = BaseAlert.ALLOWED_PROPERTIES | {
         'id',
         'channel',
-        'starts_at',
         'approved_at',
         'cancelled_at',
         'finishes_at',
-        'content',
         'areas',
     }
 
@@ -30,10 +39,6 @@ class Alert(SerialisedModel):
             return self.areas["aggregate_names"]
 
         return self.areas.get("names", [])
-
-    @property
-    def starts_at_date(self):
-        return AlertDate(self.starts_at)
 
     @property
     def approved_at_date(self):
@@ -73,3 +78,12 @@ class Alert(SerialisedModel):
             self.expires_date.as_utc_datetime >= now and
             self.approved_at_date.as_utc_datetime <= now
         )
+
+
+class PlannedTest(BaseAlert):
+    ALLOWED_PROPERTIES = BaseAlert.ALLOWED_PROPERTIES | {
+        'display_areas',
+    }
+
+    def __lt__(self, other):
+        return self.starts_at < other.starts_at

--- a/app/models/alert_date.py
+++ b/app/models/alert_date.py
@@ -1,4 +1,10 @@
-from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
+import datetime
+
+import pytz
+from notifications_utils.timezones import (
+    local_timezone,
+    utc_string_to_aware_gmt_datetime,
+)
 
 
 class AlertDate(object):
@@ -7,6 +13,18 @@ class AlertDate(object):
     def __init__(self, _datetime):
         self._datetime = _datetime  # a timezone-aware UTC datetime
         self._local_datetime = utc_string_to_aware_gmt_datetime(self._datetime)
+
+    def __eq__(self, other):
+        return self._datetime == other._datetime
+
+    def __lt__(self, other):
+        return self._datetime < other._datetime
+
+    def __hash__(self):
+        return hash(self._datetime)
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self._datetime})'
 
     @property
     def time_as_lang(self):
@@ -44,6 +62,10 @@ class AlertDate(object):
         return self._local_datetime.isoformat()
 
     @property
+    def as_iso8601_date(self):
+        return self._local_datetime.date().isoformat()
+
+    @property
     def as_utc_datetime(self):
         return self._datetime
 
@@ -54,3 +76,21 @@ class AlertDate(object):
     @property
     def as_local_date(self):
         return self._local_datetime.date()
+
+    @property
+    def at_midday(self):
+        return self.__class__(
+            datetime.datetime.combine(
+                self.as_local_date,
+                datetime.time(hour=12, minute=0),
+                tzinfo=local_timezone,
+            ).astimezone(pytz.utc)
+        )
+
+    @classmethod
+    def now(cls):
+        return cls(datetime.datetime.utcnow())
+
+    @property
+    def is_today(self):
+        return self.as_local_date == self.now().as_local_date

--- a/app/models/alerts.py
+++ b/app/models/alerts.py
@@ -4,7 +4,7 @@ import yaml
 from notifications_utils.serialised_model import SerialisedModelCollection
 
 from app import alerts_api_client
-from app.models.alert import Alert
+from app.models.alert import Alert, PlannedTest
 from app.models.alert_date import AlertDate
 from app.utils import REPO, is_in_uk
 
@@ -36,6 +36,29 @@ class Alerts(SerialisedModelCollection):
         return [alert for alert in self if alert.is_public]
 
     @property
+    def test_alerts_today(self):
+        for alert in self:
+            if alert.starts_at_date.is_today and not alert.is_public:
+                # Only show at most one test alert for a given day
+                return [alert]
+        return []
+
+    @property
+    def planned_tests(self):
+        return PlannedTests.from_yaml()
+
+    @property
+    def current_and_planned_test_alerts(self):
+        return self.test_alerts_today + self.planned_tests
+
+    @property
+    def dates_of_current_and_planned_test_alerts(self):
+        return {
+            alert.starts_at_date.at_midday
+            for alert in self.current_and_planned_test_alerts
+        }
+
+    @property
     def last_updated(self):
         return max(alert.starts_at for alert in self.current_and_public)
 
@@ -46,7 +69,6 @@ class Alerts(SerialisedModelCollection):
     @classmethod
     def load(cls):
         data = cls.from_yaml() + cls.from_api()
-
         return cls([
             alert_dict for alert_dict in data
             if 'simple_polygons' not in alert_dict['areas'] or
@@ -61,3 +83,13 @@ class Alerts(SerialisedModelCollection):
     def from_yaml(cls, path=REPO / 'data.yaml'):
         with path.open() as stream:
             return yaml.load(stream, Loader=yaml.CLoader)['alerts']
+
+
+class PlannedTests(SerialisedModelCollection):
+    model = PlannedTest
+
+    @classmethod
+    def from_yaml(cls, path=REPO / 'planned-tests.yaml'):
+        data = yaml.load(path.read_bytes(), Loader=yaml.CLoader)
+
+        return cls(data['planned_tests'])

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -13,11 +13,26 @@
 {% endmacro %}
 
 
-{% macro planned_tests_banner(number_of_alerts, subtitle) %}
+{% macro planned_tests_banner(number_of_test_alerts, dates_of_test_alerts) %}
+
+  {% set subtitle %}
+    {% for alert_date in dates_of_test_alerts|sort %}
+      {% if loop.index == 1 %}
+        <time datetime="{{ alert_date.as_iso8601_date }}">{{ alert_date.date_as_lang }}</time>
+      {% elif loop.index == 2 %}
+        {% if dates_of_test_alerts|length == 2 %}
+          and <time datetime="{{ alert_date.as_iso8601_date }}">{{ alert_date.date_as_lang }}</time>
+        {% endif %}
+      {% elif loop.last %}
+        to <time datetime="{{ alert_date.as_iso8601_date }}">{{ alert_date.date_as_lang }}</time>
+      {% endif %}
+    {% endfor %}
+  {% endset %}
+
   <div class="alerts-notification-banner alerts-icon__container alerts-icon__container--48" role="region" aria-labelledby="alerts-notification-banner__title">
     {{ alerts_icon(height=48, alert_active=False) }}
     <h2 class="alerts-notification-banner__title govuk-heading-m govuk-!-margin-bottom-1" id="alerts-notification-banner__title">
-      <a class="govuk-link govuk-link--no-visited-state" href="/alerts/planned-tests">{{ number_of_alerts }} planned {% if number_of_alerts == 1 %}test{% else %}tests{% endif %}</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="/alerts/planned-tests">{{ number_of_test_alerts }} planned {% if number_of_test_alerts == 1 %}test{% else %}tests{% endif %}</a>
     </h2>
     <p class="alerts-notification-banner__age govuk-body">
       {{ subtitle }}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -42,6 +42,9 @@
   {% if alerts.current_and_public %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
+  {% elif alerts.dates_of_current_and_planned_test_alerts %}
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    {{ planned_tests_banner(alerts.current_and_planned_test_alerts | length, alerts.dates_of_current_and_planned_test_alerts) }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -38,12 +38,20 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
-      {#
+      {% for alert in alerts.current_and_planned_test_alerts|sort %}
       <h2 class="govuk-heading-m govuk-!-margin-top-6">
-        [day of week] [day of month] [month] [year]
+        {{ alert.starts_at_date.date_as_lang }}
       </h2>
+      {% if alert.content %}
+        {% if alert.display_areas %}
+          <h3 class="govuk-body govuk-!-margin-bottom-6">
+            <span class="govuk-visually-hidden">Planned test will be sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') }}
+          </h3>
+        {% endif %}
+        {{ alert.content | paragraphize(classes="govuk-body") }}
+      {% else %}
       <p class="govuk-body">
-        Some mobile phone networks in the UK will test emergency alerts between [start hour]am and [end hour]pm.
+        Some mobile phone networks in the UK will test emergency alerts.
       </p>
       <p class="govuk-body">
         Most phones and tablets will not get a test alert.
@@ -59,13 +67,15 @@
           This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
         </p>
       </div>
-      #}
+      {% endif %}
+      {% else %}
       <p class="govuk-body">
         There are currently no planned tests of emergency alerts.
       </p>
       <p class="govuk-body">
         You can see previous tests on the <a class="govuk-link" href="/alerts/past-alerts">past alerts page</a>.
       </p>
+      {% endfor %}
     </div>
   </div>
 {% endblock %}

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -1,0 +1,12 @@
+planned_tests: []
+# Example
+#  - starts_at: 2021-08-24T13:04:38+01:00
+#    display_areas:
+#      - England
+#      - Scotland
+#      - Wales
+#      - Northern Ireland
+#    content: |
+#      Example
+#
+#      Example

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+def normalize_spaces(name):
+    return ' '.join(name.split())

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -1,6 +1,12 @@
 import base64
 import hashlib
 
+import pytest
+
+from app.models.alert import PlannedTest
+from tests import normalize_spaces
+from tests.conftest import create_planned_test_dict
+
 
 def test_index_page(client_get):
     html = client_get("alerts")
@@ -8,11 +14,84 @@ def test_index_page(client_get):
     assert 'current alert' not in html.text
 
 
-def test_index_page_shows_current_alerts(client_get, mocker, alert_dict):
+@pytest.mark.parametrize('planned_tests', (
+    ([]),
+    ([
+        PlannedTest(create_planned_test_dict()),
+    ]),
+))
+def test_index_page_shows_current_alerts(
+    client_get,
+    mocker,
+    alert_dict,
+    planned_tests,
+):
     mocker.patch('app.models.alerts.Alerts.current_and_public', ['alert'])
+    mocker.patch('app.models.alerts.Alerts.current_and_planned_test_alerts', planned_tests)
     mocker.patch('app.models.alerts.Alerts.last_updated_date')
     html = client_get("alerts")
     assert '1 current alert' in html.text
+    # Test alerts should not show on homepage when there is a current alert
+    assert 'planned test' not in html.select_one('main').text.lower()
+
+
+@pytest.mark.parametrize('current_and_planned_test_alerts, expected_banner', (
+    ([
+        PlannedTest(create_planned_test_dict(
+            starts_at='2021-02-03T00:00:00Z'
+        ))
+    ], (
+        '1 planned test '
+        'Wednesday 3 February 2021'
+    )),
+    ([
+        PlannedTest(create_planned_test_dict(
+            starts_at='2021-02-03T00:00:00Z'
+        )),
+        PlannedTest(create_planned_test_dict(
+            starts_at='2021-06-03T00:00:00Z'
+        )),
+    ], (
+        '2 planned tests '
+        'Wednesday 3 February 2021 and Thursday 3 June 2021'
+    )),
+    ([
+        PlannedTest(create_planned_test_dict(
+            starts_at='2021-02-03T00:00:00Z'
+        )),
+        PlannedTest(create_planned_test_dict(
+            starts_at='2021-06-03T00:00:00Z'
+        )),
+        PlannedTest(create_planned_test_dict(
+            starts_at='2021-06-03T23:00:01Z'
+        )),
+    ], (
+        '3 planned tests '
+        'Wednesday 3 February 2021 to Friday 4 June 2021'
+    )),
+))
+def test_index_page_shows_planned_tests(
+    client_get,
+    mocker,
+    current_and_planned_test_alerts,
+    expected_banner,
+):
+    mocker.patch('app.models.alerts.Alerts.current_and_public', [])
+    mocker.patch(
+        'app.models.alerts.Alerts.current_and_planned_test_alerts',
+        current_and_planned_test_alerts,
+    )
+
+    html = client_get("alerts")
+    assert normalize_spaces(
+        html.select_one('.alerts-notification-banner').text
+    ) == (
+        expected_banner
+    )
+
+    assert html.select_one('.alerts-notification-banner a')['href'] == (
+        '/alerts/planned-tests'
+    )
 
 
 def test_index_page_content_security_policy_sha(client_get):

--- a/tests/app/main/views/test_planned_tests.py
+++ b/tests/app/main/views/test_planned_tests.py
@@ -1,0 +1,160 @@
+import pytest
+from dateutil.parser import parse as dt_parse
+from freezegun import freeze_time
+
+from app.models.alert import PlannedTest
+from app.models.alerts import Alerts
+from tests import normalize_spaces
+from tests.conftest import create_alert_dict
+
+
+def test_planned_tests_page(mocker, client_get):
+    mocker.patch('app.models.alerts.PlannedTests.from_yaml', return_value=[])
+    html = client_get("alerts/planned-tests")
+    assert html.select_one('h1').text.strip() == "Planned tests"
+    assert [
+        normalize_spaces(p.text) for p in html.select('main p')
+    ] == [
+        'There are currently no planned tests of emergency alerts.',
+        'You can see previous tests on the past alerts page.',
+    ]
+    assert html.select_one('main p a').text == 'past alerts page'
+    assert html.select_one('main p a')['href'] == '/alerts/past-alerts'
+
+
+@pytest.mark.parametrize('data_from_yaml, expected_h2s, expected_h3s, expected_paragraphs', (
+    (
+        [PlannedTest({
+            'starts_at': '2021-02-03T00:00:00Z',
+            'content': None,
+            'display_areas': [],
+        })],
+        ['Wednesday 3 February 2021'],
+        [],
+        [
+            'Some mobile phone networks in the UK will test emergency alerts.',
+            'Most phones and tablets will not get a test alert.',
+            'Find out more about mobile network operator tests.',
+            'The alert will say:',
+            (
+                'This is a mobile network operator test of the Emergency Alerts '
+                'service. You do not need to take any action. To find out more, '
+                'search for gov.uk/alerts'
+            ),
+        ]
+    ),
+    (
+        [PlannedTest({
+            'starts_at': '2021-02-03T23:00:00Z',
+            'content': 'Paragraph 1\n\nParagraph 2',
+            'display_areas': ['Ibiza', 'The Norfolk Broads'],
+        })],
+        ['Wednesday 3 February 2021'],
+        ['Planned test will be sent to Ibiza and The Norfolk Broads'],
+        [
+            'Paragraph 1',
+            'Paragraph 2',
+        ]
+    ),
+    (
+        [
+            PlannedTest({
+                'starts_at': '2021-02-03T00:00:00Z',
+                'content': 'Paragraph 1\n\nParagraph 2',
+                'display_areas': ['Ibiza'],
+            }),
+            PlannedTest({
+                'starts_at': '2021-02-03T01:00:00Z',
+                'content': 'Paragraph 3\n\nParagraph 4',
+                'display_areas': ['The Norfolk Broads'],
+            }),
+        ],
+        [
+            # Not aggregated because it’s unlikely we’ll plan two
+            # different tests on the same day
+            'Wednesday 3 February 2021', 'Wednesday 3 February 2021'
+        ],
+        [
+            'Planned test will be sent to Ibiza',
+            'Planned test will be sent to The Norfolk Broads'],
+        [
+            'Paragraph 1',
+            'Paragraph 2',
+            'Paragraph 3',
+            'Paragraph 4',
+        ]
+    ),
+))
+def test_planned_tests_page_with_upcoming_test(
+    mocker,
+    client_get,
+    data_from_yaml,
+    expected_h2s,
+    expected_h3s,
+    expected_paragraphs,
+):
+    mocker.patch('app.models.alerts.PlannedTests.from_yaml', return_value=data_from_yaml)
+    html = client_get("alerts/planned-tests")
+    assert [
+        normalize_spaces(h2.text) for h2 in html.select('main h2')
+    ] == expected_h2s
+    assert [
+        normalize_spaces(h3.text) for h3 in html.select('main h3')
+    ] == expected_h3s
+    assert [
+        normalize_spaces(p.text) for p in html.select('main p')
+    ] == expected_paragraphs
+
+
+@pytest.mark.parametrize('extra_json_fields', (
+    # Doesn’t matter if the alert is still active…
+    {},
+    # Or if it’s cancelled before now
+    {'cancelled_at': dt_parse('2021-04-21T10:00:00Z')},
+    # Or if it’s finished already
+    {'finishes_at': dt_parse('2021-04-21T10:00:00Z')},
+))
+@freeze_time('2021-04-21T11:00:00Z')
+def test_planned_tests_page_with_current_operator_test(
+    mocker,
+    client_get,
+    extra_json_fields,
+):
+    mocker.patch('app.models.alerts.PlannedTests.from_yaml', return_value=[])
+    mocker.patch('app.models.alerts.Alerts.load', return_value=Alerts([
+        create_alert_dict(
+            channel='operator',
+            starts_at=dt_parse('2021-04-21T09:00:00Z'),
+            **extra_json_fields
+        )
+    ]))
+    html = client_get("alerts/planned-tests")
+    assert [
+        normalize_spaces(h2.text) for h2 in html.select('main h2')
+    ] == [
+        'Wednesday 21 April 2021'
+    ]
+    assert not html.select('main h3')
+    assert [
+        normalize_spaces(p.text) for p in html.select('main p')
+    ] == [
+        'Something'
+    ]
+
+
+@freeze_time('2021-04-21T11:00:00Z')
+def test_planned_tests_page_with_previous_days_operator_test(
+    mocker,
+    client_get,
+):
+    mocker.patch('app.models.alerts.PlannedTests.from_yaml', return_value=[])
+    mocker.patch('app.models.alerts.Alerts.load', return_value=Alerts([
+        create_alert_dict(
+            channel='operator',
+            starts_at=dt_parse('2021-04-20T09:00:00Z'),
+        )
+    ]))
+    html = client_get("alerts/planned-tests")
+    assert normalize_spaces(html.select_one('main p').text) == (
+        'There are currently no planned tests of emergency alerts.'
+    )

--- a/tests/app/models/test_alert.py
+++ b/tests/app/models/test_alert.py
@@ -2,8 +2,9 @@ import pytest
 from dateutil.parser import parse as dt_parse
 from freezegun import freeze_time
 
-from app.models.alert import Alert
+from app.models.alert import Alert, PlannedTest
 from app.models.alert_date import AlertDate
+from tests.conftest import create_alert_dict, create_planned_test_dict
 
 
 def test_alert_timestamps_properties_are_AlertDates(alert_dict):
@@ -14,14 +15,26 @@ def test_alert_timestamps_properties_are_AlertDates(alert_dict):
     assert isinstance(alert.starts_at_date, AlertDate)
 
 
-def test_lt_compares_alerts_based_on_start_date(alert_dict):
-    alert_dict_1 = {**alert_dict}
-    alert_dict_2 = {**alert_dict}
+def test_planned_test_timestamps_properties_are_AlertDates(planned_test_dict):
+    planned_test = PlannedTest(planned_test_dict)
+    assert isinstance(planned_test.starts_at_date, AlertDate)
+    assert not hasattr(planned_test, 'approved_at_date')
+    assert not hasattr(planned_test, 'cancelled_at_date')
+    assert not hasattr(planned_test, 'finishes_at_date')
+
+
+@pytest.mark.parametrize('model, fixture', (
+    (Alert, create_alert_dict),
+    (PlannedTest, create_planned_test_dict),
+))
+def test_lt_compares_alerts_based_on_start_date(model, fixture):
+    alert_dict_1 = fixture()
+    alert_dict_2 = fixture()
 
     alert_dict_1['starts_at'] = dt_parse('2021-04-21T11:30:00Z')
     alert_dict_2['starts_at'] = dt_parse('2021-04-21T12:30:00Z')
 
-    assert Alert(alert_dict_1) < Alert(alert_dict_2)
+    assert model(alert_dict_1) < model(alert_dict_2)
 
 
 def test_display_areas_falls_back_to_granular_names(alert_dict):
@@ -35,6 +48,21 @@ def test_display_areas_falls_back_to_granular_names(alert_dict):
 
     del alert_dict['areas']['names']
     assert Alert(alert_dict).display_areas == []
+
+
+def test_planned_test_only_has_display_areas():
+    assert PlannedTest(
+        create_planned_test_dict()
+    ).display_areas == []
+
+    assert PlannedTest(
+        create_planned_test_dict(display_areas=['a', 'b'])
+    ).display_areas == ['a', 'b']
+
+    assert not hasattr(
+        PlannedTest(create_planned_test_dict()),
+        'areas',
+    )
 
 
 def test_expires_date_returns_earliest_expiry_time(alert_dict):
@@ -104,7 +132,8 @@ def test_is_current_and_public(is_current, is_public, is_current_and_public, moc
 @pytest.mark.parametrize('channel,is_public', [
     ['severe', True],
     ['government', True],
-    ['operator', False]
+    ['operator', False],
+    ['test', False]
 ])
 def test_is_public(channel, is_public, alert_dict):
     alert_dict['channel'] = channel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,26 @@ def create_alert_dict(
     }
 
 
+def create_planned_test_dict(
+    starts_at=None,
+    display_areas=None,
+    content=None,
+):
+    return {
+        'starts_at': starts_at or dt_parse('2021-04-21T11:30:00Z'),
+        'display_areas': display_areas or [],
+        'content': content,
+    }
+
+
 @pytest.fixture()
 def alert_dict():
     return create_alert_dict()
+
+
+@pytest.fixture()
+def planned_test_dict():
+    return create_planned_test_dict()
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
At the moment, whenever there is a planned test we need to update and deploy gov.uk/alerts manually.

We also update the site manually to announce upcoming public tests, like Reading.

This commit:
- automatically puts a banner on the homepage and updates the ‘Planned tests’ page whenever there is an operator test happening on a given day
- gives us a way of publishing details of upcoming public tests without having to directly edit HTML (it’s yet another YAML file)

I’ve even made it work in the case when there’s an upcoming public test, and a current operator test, like we had in the run-up to Reading.

For operator tests the banner will stay up until the end of the day. I think this is sensible since the test might not last for very long, and there might be several in one day (which we treat as one). For this to work in a completely automated way we will need to schedule republishing of the site at 00:01 each day.

If we do this then the MNOs don’t need to arrange their planned tests with us in advance, reducing our support burden.

With some fake data:

![image](https://user-images.githubusercontent.com/355079/132247936-11f2f0ea-2cbc-4887-807b-414fc1ab69fc.png)

![image](https://user-images.githubusercontent.com/355079/132247968-acf08405-18a1-41cd-9eea-6adae9c0a899.png)

![image](https://user-images.githubusercontent.com/355079/132248002-40a7739e-ca96-48ed-b4c1-083c0f898676.png)

***

<sup>Sorry for the mega commit</sup>