### PR TITLE
Add planned operator test for 9/9/21

### DIFF
--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -42,6 +42,9 @@
   {% if alerts.current_and_public %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
+  {% else %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  {{ planned_tests_banner(1, 'Thursday 9 September 2021') }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -45,7 +45,7 @@
         Some mobile phone networks in the UK will test emergency alerts between 10am and 11am.
       </p>
       <p class="govuk-body">
-        Most phones and tablets will not get a test alert.
+        Most phones and tablets will not get a test alert. A small number of people may receive 2.
       </p>
       <p class="govuk-body">
         Find out more <a class="govuk-link" href="/alerts/mobile-network-operator-tests">about mobile network operator tests</a>.

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -38,12 +38,11 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
-      {#
       <h2 class="govuk-heading-m govuk-!-margin-top-6">
-        [day of week] [day of month] [month] [year]
+        Thursday 9 September 2021
       </h2>
       <p class="govuk-body">
-        Some mobile phone networks in the UK will test emergency alerts between 1pm and 2pm.
+        Some mobile phone networks in the UK will test emergency alerts between 10am and 11am.
       </p>
       <p class="govuk-body">
         Most phones and tablets will not get a test alert.
@@ -59,13 +58,14 @@
           This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
         </p>
       </div>
-      #}
+      {#
       <p class="govuk-body">
         There are currently no planned tests of emergency alerts.
       </p>
       <p class="govuk-body">
         You can see previous tests on the <a class="govuk-link" href="/alerts/past-alerts">past alerts page</a>.
       </p>
+      #}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Note, there will be two alerts sent, one at 10 and one at 10:15
but we can potentially just tell the user it will be 1 planned test.
Will need sign off from Karl.