### PR TITLE
 Remove old entry for severe Suffolk alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,6 @@ To run a specific JavaScript test, you'll need to copy the full command from `pa
 
 ## Further documentation
 
-- [Image optimisation](docs/image-optimisation.md)
 - [Architecture](docs/architecture.md)
+- [Image optimisation](docs/image-optimisation.md)
+- [Setting up redirects](docs/redirects.md)

--- a/data.yaml
+++ b/data.yaml
@@ -211,20 +211,3 @@ alerts:
       simple_polygons: [[[52.22035, 1.58242], [52.19521, 1.58491], [52.19325, 1.59971], [52.19372, 1.62352], [52.21901, 1.62599], [52.22035, 1.58242]]]
       aggregate_names:
         - East Suffolk
-### ^^^ REMOVE BELOW AFTER REDIRECTS LAMBDA IS DEPLOYED ^^^ ###
-  - identifier: 3-may-2021
-    channel: severe
-    approved_at: 2021-05-25T13:00:14+01:00
-    starts_at: 2021-05-25T13:00:14+01:00
-    cancelled_at: 2021-05-25T13:20:05+01:00
-    finishes_at: 2021-05-25T17:00:14+01:00
-    content: |
-      The UK government is testing Emergency Alerts in East Suffolk.
-
-      Emergency alerts tell you what to do if there’s a life-threatening event nearby.
-
-      To find out more, call 0808 1697692 or search for gov.uk/alerts
-    areas:
-      simple_polygons: [[[52.22035, 1.58242], [52.19521, 1.58491], [52.19325, 1.59971], [52.19372, 1.62352], [52.21901, 1.62599], [52.22035, 1.58242]]]
-      aggregate_names:
-        - East Suffolk

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -1,0 +1,15 @@
+# Redirects
+
+If you need to set up a new redirect, you can do that in our notifications-broadcasts-infra repository.
+
+In there, head to `terraform/modules/govuk-alerts-website/files/redirects` and add your redirect to REDIRECTS constant, using the following format:
+
+```
+REDIRECTS = {"<uri of page you want to redirect from>": "<uri of page you want to redirect to>"}
+```
+
+Deploy-wise, you will need to do 3 deploys in quick succession:
+
+1. deploy a PR that adds the page to redirect to
+2. deploy the lambda change (through govuk-alerts-infra Concourse pipeline)
+3. deploy a PR that removed the old page we want to get rid of


### PR DESCRIPTION
If someone goes to the address for the old entry, we will redirect them.

Needs to go in after https://github.com/alphagov/notifications-govuk-alerts/pull/180 and after we deploy lambda changes to support redirects.

TODO: make a note in the README that if you want to put in a redirect, you do it through Terraform/lambda in the infra repo