### PR TITLE
Add planned operator test for 17 Sept

### DIFF
--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -42,6 +42,9 @@
   {% if alerts.current_and_public %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
+  {% else %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  {{ planned_tests_banner(1, 'Friday 17 September 2021') }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -38,15 +38,14 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
-      {#
       <h2 class="govuk-heading-m govuk-!-margin-top-6">
-        [day of week] [day of month] [month] [year]
+        Friday 17 September 2021
       </h2>
       <p class="govuk-body">
-        Some mobile phone networks in the UK will test emergency alerts between [start hour]am and [end hour]pm.
+        Some mobile phone networks in the UK will test emergency alerts between 10am and 12pm.
       </p>
       <p class="govuk-body">
-        Most phones and tablets will not get a test alert.
+        Most phones and tablets will not get a test alert. A small number of people may receive 2.
       </p>
       <p class="govuk-body">
         Find out more <a class="govuk-link" href="/alerts/mobile-network-operator-tests">about mobile network operator tests</a>.
@@ -59,13 +58,14 @@
           This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
         </p>
       </div>
-      #}
+      {#
       <p class="govuk-body">
         There are currently no planned tests of emergency alerts.
       </p>
       <p class="govuk-body">
         You can see previous tests on the <a class="govuk-link" href="/alerts/past-alerts">past alerts page</a>.
       </p>
+      #}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Two alerts will be sent. One at 10:15 and one at 11:00.
Both will be cancelled after 15 minutes.

This follows the precedent of https://github.com/alphagov/notifications-govuk-alerts/pull/176
where we refer to a small number of users receiving two alerts.