### PR TITLE
Take down emergency alert test from 17 sept.

### DIFF
--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -42,9 +42,6 @@
   {% if alerts.current_and_public %}
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
-  {% else %}
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  {{ planned_tests_banner(1, 'Friday 17 September 2021') }}
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -38,14 +38,15 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
+      {#
       <h2 class="govuk-heading-m govuk-!-margin-top-6">
-        Friday 17 September 2021
+        [day of week] [day of month] [month] [year]
       </h2>
       <p class="govuk-body">
-        Some mobile phone networks in the UK will test emergency alerts between 10am and 12pm.
+        Some mobile phone networks in the UK will test emergency alerts between [start hour]am and [end hour]pm.
       </p>
       <p class="govuk-body">
-        Most phones and tablets will not get a test alert. A small number of people may receive 2.
+        Most phones and tablets will not get a test alert.
       </p>
       <p class="govuk-body">
         Find out more <a class="govuk-link" href="/alerts/mobile-network-operator-tests">about mobile network operator tests</a>.
@@ -58,14 +59,13 @@
           This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
         </p>
       </div>
-      {#
+      #}
       <p class="govuk-body">
         There are currently no planned tests of emergency alerts.
       </p>
       <p class="govuk-body">
         You can see previous tests on the <a class="govuk-link" href="/alerts/past-alerts">past alerts page</a>.
       </p>
-      #}
     </div>
   </div>
 {% endblock %}

--- a/data.yaml
+++ b/data.yaml
@@ -1,6 +1,24 @@
 alerts:
   - identifier:
     channel: operator
+    approved_at: 2021-09-17T11:00:00+01:00
+    starts_at: 2021-09-17T11:00:00+01:00
+    cancelled_at: 2021-09-17T11:15:00+01:00
+    finishes_at: 2021-09-17T11:15:00+01:00
+    content: |
+      This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
+    areas: {}
+  - identifier:
+    channel: operator
+    approved_at: 2021-09-17T10:00:00+01:00
+    starts_at: 2021-09-17T10:00:00+01:00
+    cancelled_at: 2021-09-17T10:15:00+01:00
+    finishes_at: 2021-09-17T10:15:00+01:00
+    content: |
+      This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
+    areas: {}
+  - identifier:
+    channel: operator
     approved_at: 2021-09-10T13:00:00+01:00
     starts_at: 2021-09-10T13:00:00+01:00
     cancelled_at: 2021-09-10T14:00:00+01:00


### PR DESCRIPTION
Reverts alphagov/notifications-govuk-alerts#182 and adds the two tests to the list of past alerts data.yaml file.