### PR TITLE
Duplicate Reading test alert to allow for redirect

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -163,6 +163,21 @@ alerts:
       This is a mobile network operator test of the Emergency Alerts service. You do not need to take any action. To find out more, search for gov.uk/alerts
     areas: {}
 ### ^^^ DO NOT DELETE: NOT IN DB ^^^ ###
+  - identifier: 29-jun-2021
+    channel: severe
+    approved_at: 2021-06-29T13:00:12+01:00
+    starts_at: 2021-06-29T13:00:12+01:00
+    cancelled_at: 2021-06-29T14:01:19+01:00
+    finishes_at: 2021-06-29T17:00:12+01:00
+    content: |
+      The UK government is testing Emergency Alerts in Reading, Berkshire.
+
+      Emergency alerts tell you what to do if there’s a life-threatening event nearby.
+
+      To find out more, call 0808 1697692 or search for gov.uk/alerts
+    areas:
+      aggregate_names:
+        - Reading
   - identifier: 29-june-2021
     channel: severe
     approved_at: 2021-06-29T13:00:12+01:00


### PR DESCRIPTION
We need to change the url of this alert from
21-june-2021 to 21-jun-2021.

Therefore we duplicate the alert for a short period until we
have deployed the redirect in terraform at which point we will then
remove the old alert from the data.yaml file.