### PR TITLE
Rename purge_cache to make it easier to find

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -3,7 +3,7 @@ from flask import current_app
 from app import notify_celery
 from app.models.alerts import Alerts
 from app.render import get_rendered_pages
-from app.utils import purge_cache, upload_to_s3
+from app.utils import purge_fastly_cache, upload_to_s3
 
 
 @notify_celery.task(bind=True, name="publish-govuk-alerts", max_retries=20, retry_backoff=True, retry_backoff_max=300)
@@ -13,7 +13,7 @@ def publish_govuk_alerts(self):
         rendered_pages = get_rendered_pages(alerts)
 
         upload_to_s3(rendered_pages)
-        purge_cache()
+        purge_fastly_cache()
     except Exception:
         current_app.logger.exception("Failed to publish content to gov.uk/alerts")
         self.retry(queue=current_app.config['QUEUE_NAME'])

--- a/app/utils.py
+++ b/app/utils.py
@@ -65,7 +65,7 @@ def upload_to_s3(rendered_pages):
         item.put(Body=content, ContentType="text/html")
 
 
-def purge_cache():
+def purge_fastly_cache():
     fastly_service_id = current_app.config['FASTLY_SERVICE_ID']
     fastly_api_key = current_app.config['FASTLY_API_KEY']
     surrogate_key = current_app.config['FASTLY_SURROGATE_KEY']

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -9,9 +9,9 @@ from app.celery.tasks import publish_govuk_alerts
 @patch('app.celery.tasks.Alerts.load')
 @patch('app.celery.tasks.get_rendered_pages')
 @patch('app.celery.tasks.upload_to_s3')
-@patch('app.celery.tasks.purge_cache')
+@patch('app.celery.tasks.purge_fastly_cache')
 def test_publish_govuk_alerts(
-    mock_purge_cache,
+    mock_purge_fastly_cache,
     mock_upload_to_s3,
     mock_get_rendered_pages,
     mock_Alerts_load,
@@ -20,7 +20,7 @@ def test_publish_govuk_alerts(
     mock_Alerts_load.assert_called_once()
     mock_get_rendered_pages.assert_called_once_with(mock_Alerts_load.return_value)
     mock_upload_to_s3.assert_called_once_with(mock_get_rendered_pages.return_value)
-    mock_purge_cache.assert_called_once()
+    mock_purge_fastly_cache.assert_called_once()
 
 
 @patch('app.celery.tasks.Alerts.load')

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -10,7 +10,7 @@ from app.utils import (
     file_fingerprint,
     is_in_uk,
     paragraphize,
-    purge_cache,
+    purge_fastly_cache,
     upload_to_s3,
 )
 
@@ -65,13 +65,13 @@ def test_upload_to_s3(govuk_alerts):
 
 
 @patch('app.utils.requests')
-def test_purge_cache(mock_requests, govuk_alerts):
+def test_purge_fastly_cache(mock_requests, govuk_alerts):
     headers = {
         "Accept": "application/json",
         "Fastly-Key": "test-api-key"
     }
 
-    purge_cache()
+    purge_fastly_cache()
 
     fastly_url = "https://api.fastly.com/service/test-service-id/purge/test-surrogate-key"
     mock_requests.post.assert_called_once_with(fastly_url, headers=headers)


### PR DESCRIPTION
This code doesn't show up if we search for "fastly", which is a
reasonable query to type.