### PR TITLE
Hide content and areas of operator tests

### DIFF
--- a/app/models/alert.py
+++ b/app/models/alert.py
@@ -6,21 +6,12 @@ from notifications_utils.serialised_model import SerialisedModel
 from app.models.alert_date import AlertDate
 
 
-class BaseAlert(SerialisedModel):
+class Alert(SerialisedModel):
     ALLOWED_PROPERTIES = {
-        'starts_at',
-    }
-
-    @property
-    def starts_at_date(self):
-        return AlertDate(self.starts_at)
-
-
-class Alert(BaseAlert):
-    ALLOWED_PROPERTIES = BaseAlert.ALLOWED_PROPERTIES | {
         'id',
         'channel',
         'approved_at',
+        'starts_at',
         'cancelled_at',
         'finishes_at',
         'areas',
@@ -46,6 +37,10 @@ class Alert(BaseAlert):
     @property
     def approved_at_date(self):
         return AlertDate(self.approved_at)
+
+    @property
+    def starts_at_date(self):
+        return AlertDate(self.starts_at)
 
     @property
     def expires_date(self):
@@ -81,13 +76,3 @@ class Alert(BaseAlert):
             self.expires_date.as_utc_datetime >= now and
             self.approved_at_date.as_utc_datetime <= now
         )
-
-
-class PlannedTest(BaseAlert):
-    ALLOWED_PROPERTIES = BaseAlert.ALLOWED_PROPERTIES | {
-        'display_areas',
-        'description',
-    }
-
-    def __lt__(self, other):
-        return self.starts_at < other.starts_at

--- a/app/models/alert.py
+++ b/app/models/alert.py
@@ -9,7 +9,6 @@ from app.models.alert_date import AlertDate
 class BaseAlert(SerialisedModel):
     ALLOWED_PROPERTIES = {
         'starts_at',
-        'content',
     }
 
     @property
@@ -25,6 +24,7 @@ class Alert(BaseAlert):
         'cancelled_at',
         'finishes_at',
         'areas',
+        'content',
     }
 
     def __lt__(self, other):
@@ -35,6 +35,9 @@ class Alert(BaseAlert):
 
     @property
     def display_areas(self):
+        if not self.is_public:
+            return []
+
         if "aggregate_names" in self.areas:
             return self.areas["aggregate_names"]
 
@@ -83,6 +86,7 @@ class Alert(BaseAlert):
 class PlannedTest(BaseAlert):
     ALLOWED_PROPERTIES = BaseAlert.ALLOWED_PROPERTIES | {
         'display_areas',
+        'description',
     }
 
     def __lt__(self, other):

--- a/app/models/alerts.py
+++ b/app/models/alerts.py
@@ -4,8 +4,9 @@ import yaml
 from notifications_utils.serialised_model import SerialisedModelCollection
 
 from app import alerts_api_client
-from app.models.alert import Alert, PlannedTest
+from app.models.alert import Alert
 from app.models.alert_date import AlertDate
+from app.models.planned_tests import PlannedTests
 from app.utils import REPO, is_in_uk
 
 
@@ -83,13 +84,3 @@ class Alerts(SerialisedModelCollection):
     def from_yaml(cls, path=REPO / 'data.yaml'):
         with path.open() as stream:
             return yaml.load(stream, Loader=yaml.CLoader)['alerts']
-
-
-class PlannedTests(SerialisedModelCollection):
-    model = PlannedTest
-
-    @classmethod
-    def from_yaml(cls, path=REPO / 'planned-tests.yaml'):
-        data = yaml.load(path.read_bytes(), Loader=yaml.CLoader)
-
-        return cls(data['planned_tests'])

--- a/app/models/planned_test.py
+++ b/app/models/planned_test.py
@@ -1,0 +1,18 @@
+from notifications_utils.serialised_model import SerialisedModel
+
+from app.models.alert_date import AlertDate
+
+
+class PlannedTest(SerialisedModel):
+    ALLOWED_PROPERTIES = {
+        'description',
+        'display_areas',
+        'starts_at',
+    }
+
+    def __lt__(self, other):
+        return self.starts_at < other.starts_at
+
+    @property
+    def starts_at_date(self):
+        return AlertDate(self.starts_at)

--- a/app/models/planned_tests.py
+++ b/app/models/planned_tests.py
@@ -1,0 +1,15 @@
+import yaml
+from notifications_utils.serialised_model import SerialisedModelCollection
+
+from app.models.planned_test import PlannedTest
+from app.utils import REPO
+
+
+class PlannedTests(SerialisedModelCollection):
+    model = PlannedTest
+
+    @classmethod
+    def from_yaml(cls, path=REPO / 'planned-tests.yaml'):
+        data = yaml.load(path.read_bytes(), Loader=yaml.CLoader)
+
+        return cls(data['planned_tests'])

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -42,13 +42,13 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-6">
         {{ alert.starts_at_date.date_as_lang }}
       </h2>
-      {% if alert.content %}
+      {% if alert.description %}
         {% if alert.display_areas %}
           <h3 class="govuk-body govuk-!-margin-bottom-6">
             <span class="govuk-visually-hidden">Planned test will be sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') }}
           </h3>
         {% endif %}
-        {{ alert.content | paragraphize(classes="govuk-body") }}
+        {{ alert.description | paragraphize(classes="govuk-body") }}
       {% else %}
       <p class="govuk-body">
         Some mobile phone networks in the UK will test emergency alerts.

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -38,17 +38,21 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
-      {% for alert in alerts.current_and_planned_test_alerts|sort %}
+      {% for alert_or_planned_test in alerts.current_and_planned_test_alerts|sort %}
       <h2 class="govuk-heading-m govuk-!-margin-top-6">
-        {{ alert.starts_at_date.date_as_lang }}
+        {{ alert_or_planned_test.starts_at_date.date_as_lang }}
       </h2>
-      {% if alert.description %}
-        {% if alert.display_areas %}
+      {#
+        Only planned tests have a description – for real alerts we show
+        fixed content (below).
+      #}
+      {% if alert_or_planned_test.description %}
+        {% if alert_or_planned_test.display_areas %}
           <h3 class="govuk-body govuk-!-margin-bottom-6">
-            <span class="govuk-visually-hidden">Planned test will be sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') }}
+            <span class="govuk-visually-hidden">Planned test will be sent to </span>{{ alert_or_planned_test.display_areas | formatted_list(before_each='', after_each='') }}
           </h3>
         {% endif %}
-        {{ alert.description | paragraphize(classes="govuk-body") }}
+        {{ alert_or_planned_test.description | paragraphize(classes="govuk-body") }}
       {% else %}
       <p class="govuk-body">
         Some mobile phone networks in the UK will test emergency alerts.

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -6,7 +6,7 @@ planned_tests: []
 #      - Scotland
 #      - Wales
 #      - Northern Ireland
-#    content: |
-#      Example
+#    description: |
+#      The UK goverment will test Emergency Alerts between […]
 #
-#      Example
+#      If you get an alert […]

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -3,7 +3,7 @@ import hashlib
 
 import pytest
 
-from app.models.alert import PlannedTest
+from app.models.planned_test import PlannedTest
 from tests import normalize_spaces
 from tests.conftest import create_planned_test_dict
 

--- a/tests/app/main/views/test_planned_tests.py
+++ b/tests/app/main/views/test_planned_tests.py
@@ -26,7 +26,7 @@ def test_planned_tests_page(mocker, client_get):
     (
         [PlannedTest({
             'starts_at': '2021-02-03T00:00:00Z',
-            'content': None,
+            'description': None,
             'display_areas': [],
         })],
         ['Wednesday 3 February 2021'],
@@ -46,7 +46,7 @@ def test_planned_tests_page(mocker, client_get):
     (
         [PlannedTest({
             'starts_at': '2021-02-03T23:00:00Z',
-            'content': 'Paragraph 1\n\nParagraph 2',
+            'description': 'Paragraph 1\n\nParagraph 2',
             'display_areas': ['Ibiza', 'The Norfolk Broads'],
         })],
         ['Wednesday 3 February 2021'],
@@ -60,12 +60,12 @@ def test_planned_tests_page(mocker, client_get):
         [
             PlannedTest({
                 'starts_at': '2021-02-03T00:00:00Z',
-                'content': 'Paragraph 1\n\nParagraph 2',
+                'description': 'Paragraph 1\n\nParagraph 2',
                 'display_areas': ['Ibiza'],
             }),
             PlannedTest({
                 'starts_at': '2021-02-03T01:00:00Z',
-                'content': 'Paragraph 3\n\nParagraph 4',
+                'description': 'Paragraph 3\n\nParagraph 4',
                 'display_areas': ['The Norfolk Broads'],
             }),
         ],
@@ -138,7 +138,15 @@ def test_planned_tests_page_with_current_operator_test(
     assert [
         normalize_spaces(p.text) for p in html.select('main p')
     ] == [
-        'Something'
+        'Some mobile phone networks in the UK will test emergency alerts.',
+        'Most phones and tablets will not get a test alert.',
+        'Find out more about mobile network operator tests.',
+        'The alert will say:',
+        (
+            'This is a mobile network operator test of the Emergency Alerts '
+            'service. You do not need to take any action. To find out more, '
+            'search for gov.uk/alerts'
+        ),
     ]
 
 

--- a/tests/app/main/views/test_planned_tests.py
+++ b/tests/app/main/views/test_planned_tests.py
@@ -2,8 +2,8 @@ import pytest
 from dateutil.parser import parse as dt_parse
 from freezegun import freeze_time
 
-from app.models.alert import PlannedTest
 from app.models.alerts import Alerts
+from app.models.planned_test import PlannedTest
 from tests import normalize_spaces
 from tests.conftest import create_alert_dict
 

--- a/tests/app/models/test_alert.py
+++ b/tests/app/models/test_alert.py
@@ -138,3 +138,17 @@ def test_is_current_and_public(is_current, is_public, is_current_and_public, moc
 def test_is_public(channel, is_public, alert_dict):
     alert_dict['channel'] = channel
     assert Alert(alert_dict).is_public == is_public
+
+
+@pytest.mark.parametrize('channel, expected_display_areas', [
+    ('severe', ['Chipping Sodbury']),
+    ('government', ['Chipping Sodbury']),
+    ('operator', []),
+    ('test', [])
+])
+def test_displayed_areas_for_public_alerts_only(
+    channel, expected_display_areas, alert_dict
+):
+    alert_dict['channel'] = channel
+    alert_dict['areas']['aggregate_names'] = ['Chipping Sodbury']
+    assert Alert(alert_dict).display_areas == expected_display_areas

--- a/tests/app/models/test_alert.py
+++ b/tests/app/models/test_alert.py
@@ -2,9 +2,9 @@ import pytest
 from dateutil.parser import parse as dt_parse
 from freezegun import freeze_time
 
-from app.models.alert import Alert, PlannedTest
+from app.models.alert import Alert
 from app.models.alert_date import AlertDate
-from tests.conftest import create_alert_dict, create_planned_test_dict
+from tests.conftest import create_alert_dict
 
 
 def test_alert_timestamps_properties_are_AlertDates(alert_dict):
@@ -15,26 +15,14 @@ def test_alert_timestamps_properties_are_AlertDates(alert_dict):
     assert isinstance(alert.starts_at_date, AlertDate)
 
 
-def test_planned_test_timestamps_properties_are_AlertDates(planned_test_dict):
-    planned_test = PlannedTest(planned_test_dict)
-    assert isinstance(planned_test.starts_at_date, AlertDate)
-    assert not hasattr(planned_test, 'approved_at_date')
-    assert not hasattr(planned_test, 'cancelled_at_date')
-    assert not hasattr(planned_test, 'finishes_at_date')
-
-
-@pytest.mark.parametrize('model, fixture', (
-    (Alert, create_alert_dict),
-    (PlannedTest, create_planned_test_dict),
-))
-def test_lt_compares_alerts_based_on_start_date(model, fixture):
-    alert_dict_1 = fixture()
-    alert_dict_2 = fixture()
+def test_lt_compares_alerts_based_on_start_date():
+    alert_dict_1 = create_alert_dict()
+    alert_dict_2 = create_alert_dict()
 
     alert_dict_1['starts_at'] = dt_parse('2021-04-21T11:30:00Z')
     alert_dict_2['starts_at'] = dt_parse('2021-04-21T12:30:00Z')
 
-    assert model(alert_dict_1) < model(alert_dict_2)
+    assert Alert(alert_dict_1) < Alert(alert_dict_2)
 
 
 def test_display_areas_falls_back_to_granular_names(alert_dict):
@@ -48,21 +36,6 @@ def test_display_areas_falls_back_to_granular_names(alert_dict):
 
     del alert_dict['areas']['names']
     assert Alert(alert_dict).display_areas == []
-
-
-def test_planned_test_only_has_display_areas():
-    assert PlannedTest(
-        create_planned_test_dict()
-    ).display_areas == []
-
-    assert PlannedTest(
-        create_planned_test_dict(display_areas=['a', 'b'])
-    ).display_areas == ['a', 'b']
-
-    assert not hasattr(
-        PlannedTest(create_planned_test_dict()),
-        'areas',
-    )
 
 
 def test_expires_date_returns_earliest_expiry_time(alert_dict):

--- a/tests/app/models/test_alert.py
+++ b/tests/app/models/test_alert.py
@@ -119,7 +119,7 @@ def test_is_public(channel, is_public, alert_dict):
     ('operator', []),
     ('test', [])
 ])
-def test_displayed_areas_for_public_alerts_only(
+def test_display_areas_shows_public_alerts_only(
     channel, expected_display_areas, alert_dict
 ):
     alert_dict['channel'] = channel

--- a/tests/app/models/test_planned_test.py
+++ b/tests/app/models/test_planned_test.py
@@ -1,0 +1,38 @@
+from dateutil.parser import parse as dt_parse
+
+from app.models.alert_date import AlertDate
+from app.models.planned_test import PlannedTest
+from tests.conftest import create_planned_test_dict
+
+
+def test_planned_test_timestamps_properties_are_AlertDates(planned_test_dict):
+    planned_test = PlannedTest(planned_test_dict)
+    assert isinstance(planned_test.starts_at_date, AlertDate)
+    assert not hasattr(planned_test, 'approved_at_date')
+    assert not hasattr(planned_test, 'cancelled_at_date')
+    assert not hasattr(planned_test, 'finishes_at_date')
+
+
+def test_lt_compares_alerts_based_on_start_date():
+    alert_dict_1 = create_planned_test_dict()
+    alert_dict_2 = create_planned_test_dict()
+
+    alert_dict_1['starts_at'] = dt_parse('2021-04-21T11:30:00Z')
+    alert_dict_2['starts_at'] = dt_parse('2021-04-21T12:30:00Z')
+
+    assert PlannedTest(alert_dict_1) < PlannedTest(alert_dict_2)
+
+
+def test_planned_test_only_has_display_areas():
+    assert PlannedTest(
+        create_planned_test_dict()
+    ).display_areas == []
+
+    assert PlannedTest(
+        create_planned_test_dict(display_areas=['a', 'b'])
+    ).display_areas == ['a', 'b']
+
+    assert not hasattr(
+        PlannedTest(create_planned_test_dict()),
+        'areas',
+    )

--- a/tests/app/models/test_planned_test.py
+++ b/tests/app/models/test_planned_test.py
@@ -10,7 +10,7 @@ def test_planned_test_timestamps_properties_are_AlertDates(planned_test_dict):
     assert isinstance(planned_test.starts_at_date, AlertDate)
 
 
-def test_lt_compares_alerts_based_on_start_date():
+def test_lt_compares_planned_tests_based_on_start_date():
     alert_dict_1 = create_planned_test_dict()
     alert_dict_2 = create_planned_test_dict()
 

--- a/tests/app/models/test_planned_test.py
+++ b/tests/app/models/test_planned_test.py
@@ -8,9 +8,6 @@ from tests.conftest import create_planned_test_dict
 def test_planned_test_timestamps_properties_are_AlertDates(planned_test_dict):
     planned_test = PlannedTest(planned_test_dict)
     assert isinstance(planned_test.starts_at_date, AlertDate)
-    assert not hasattr(planned_test, 'approved_at_date')
-    assert not hasattr(planned_test, 'cancelled_at_date')
-    assert not hasattr(planned_test, 'finishes_at_date')
 
 
 def test_lt_compares_alerts_based_on_start_date():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,12 +35,12 @@ def create_alert_dict(
 def create_planned_test_dict(
     starts_at=None,
     display_areas=None,
-    content=None,
+    description=None,
 ):
     return {
         'starts_at': starts_at or dt_parse('2021-04-21T11:30:00Z'),
         'display_areas': display_areas or [],
-        'content': content,
+        'description': description,
     }
 
 


### PR DESCRIPTION
We want to always show a standard message for operator tests on the planned tests page, not the content of the alert itself.

We also don’t want to show the names of the areas targeted by an alert, because past experience has shown that people interpret this to mean that they are more likely to receive the test than they actually are.