### PR TITLE
Remove reference to ‘terrorist incidents’

### DIFF
--- a/app/templates/views/opt-out.html
+++ b/app/templates/views/opt-out.html
@@ -43,7 +43,7 @@
         You can opt out of some emergency alerts, but not the most important ones.
       </p>
       <p class="govuk-body">
-        You cannot opt out by subject, only by how serious the emergency is. If you opt out because you do not want flood warnings, for example, you might miss alerts for fires and terrorism.
+        You cannot opt out by subject, only by how serious the emergency is. If you opt out because you do not want flood warnings, for example, you might miss alerts for fires and explosions.
       </p>
       <p class="govuk-body">
         Because of this, you should keep emergency alerts switched on for your own safety.

--- a/app/templates/views/reasons-you-might-get-an-alert.html
+++ b/app/templates/views/reasons-you-might-get-an-alert.html
@@ -57,7 +57,6 @@
         <li>severe flooding</li>
         <li>fires</li>
         <li>explosions</li>
-        <li>terrorist incidents</li>
         <li>public health emergencies</li>
       </ul>
       <p class="govuk-body">


### PR DESCRIPTION
The comms folk have agreed with the National Police Chiefs Council (NPCC) to not have reference to terrorist incidents when describing Emergency Alerts and have asked for that one line to be deleted.

There’s also a reference to ‘terrorism’ on the opt-out page, this pull request also removes that instance for consistency.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/141959745-444dc24f-fc6f-4b2c-b39a-02e29299330d.png) | ![image](https://user-images.githubusercontent.com/355079/141959647-e743b77d-6ada-4ae6-8fb1-2756488d5b68.png)
![image](https://user-images.githubusercontent.com/355079/141966482-a7028f91-d463-4671-a5b2-a753d341d392.png) | ![image](https://user-images.githubusercontent.com/355079/141966460-d8560589-091e-48b8-8552-d4774bb26d6b.png) 
