### PR TITLE
Bump utils to bring in latest NotifyCelery code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ Flask==1.1.2
 pycurl==7.43.0.6
 awscli-cwlogs>=1.4,<1.5
 notifications-python-client==6.2.1
-git+https://github.com/alphagov/notifications-utils.git@48.1.0#egg=notifications-utils==48.1.0
+git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180213914

The new version of the base class:

- Reenables Celery argument checking
- Removes redundant code

See here for more details [1]. This also brings in an additional
but irrelevant change, relating to broadcast polygons.

[1]: https://github.com/alphagov/notifications-utils/pull/921