### PR TITLE
Add `title` to YouTube embed

### DIFF
--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -108,7 +108,7 @@
     <div class="govuk-grid-column-one-half">
       <div class="responsive-embed responsive-embed--16by9">
         <div class="responsive-embed__content">
-          <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/9yLd2AjGzYI" frameborder="0" allowfullscreen></iframe>
+          <iframe title="UK Emergency Alerts" width="560" height="315" src="https://www.youtube-nocookie.com/embed/9yLd2AjGzYI" frameborder="0" allowfullscreen></iframe>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This is good for accessibility. On GOV.UK they make the value of the title the same as the title of the YouTube video.