### PR TITLE
Bump utils to 51.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ Flask==1.1.2
 pycurl==7.43.0.6
 awscli-cwlogs>=1.4,<1.5
 notifications-python-client==6.2.1
-git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0
+git+https://github.com/alphagov/notifications-utils.git@51.3.0#egg=notifications-utils==51.3.0


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180693991

This brings in additional logging for the NotifyCelery base class
[1]. Although one of the other changes refers to broadcasts, the
"preview" template is only used by the Admin app.

[1]: https://github.com/alphagov/notifications-utils/blob/master/CHANGELOG.md#5130