### PR TITLE
Add PR CD warning and known testing caveat

### DIFF
--- a/.github/pull_request_template.yml
+++ b/.github/pull_request_template.yml
@@ -1,0 +1,8 @@
+
+
+
+---
+
+🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨
+
+See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,9 @@
+# Deploying
+
+See [the central documentation about merging and deploying](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment).
+
+## Caveats
+
+### The [deployment pipeline](https://github.com/alphagov/notifications-broadcasts-infra/blob/main/ci/govuk-alerts.yml) does't run functional tests for creating / approving alerts.
+
+You should manually test any changes that might affect the way the Celery worker runs or consumes from its queue e.g. changes to environment variables. This can be done locally, by deploying a branch or doing non-continuous (manual) deployment.


### PR DESCRIPTION
We have decided this is an acceptable risk:

 - Most of the functionality is covered by the smoke tests and checking the Celery worker starts.

 - Adding functional tests to the pipeline would mean copy / pasting config from the -aws repo.

 - We wouldn't be able to prevent concurrent runs of the functional tests across pipelines [1].

 - The only functionality not covered is the worker running being able to run tasks from the queue.

[1]: https://github.com/concourse/concourse/issues/2691