### PR TITLE
Bump post-deploy task timeout from 15s to 60s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,11 @@ cf-run-task-publish: cf-target
 	# successful and return a non-zero status if not;
 	# make doesn't support multiline scripts, so the "\"
 	# and ";" turn it into a oneliner with an exit status
-	for _ in 1 2 3 4 5; do \
+	for _ in 1 2 3 4 5 6; do \
 		if $(CHECK_COMMAND) | grep SUCCEEDED; then\
 			exit 0; \
 		fi; \
-		sleep 3; \
+		sleep 10; \
 	done; \
 	cf logs notify-govuk-alerts --recent; \
 	exit 1


### PR DESCRIPTION
The last 2 deploy attempts failed because the publish tasks took 23
seconds (from 2022-02-24T11:36:47Z until 2022-02-24T11:37:10Z) and 24
seconds (from 2022-02-24T12:07:19Z until 2022-02-24T12:07:43Z)
respectively.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
