### PR TITLE
Fix outdated python version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Website for emergency alerts, hosted under /alerts on GOV.UK.
 
 ### Python version
 
-At the moment we run Python 3.6 in production.
+We run Python 3.9 in production.
 
 ### NPM packages
 


### PR DESCRIPTION
It was updated as per https://github.com/alphagov/notifications-govuk-alerts/commit/21469f2c6a52545f5f0ad377c7ef3f5e2c1c7f5e




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
