### PR TITLE
Bump utils to 55.1.4 (no changes)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,4 @@ Flask==1.1.2
 pycurl==7.43.0.6
 awscli-cwlogs>=1.4,<1.5
 notifications-python-client==6.2.1
-git+https://github.com/alphagov/notifications-utils.git@51.3.0#egg=notifications-utils==51.3.0
+git+https://github.com/alphagov/notifications-utils.git@55.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@
 amqp==5.0.9
     # via kombu
 awscli==1.22.26
-    # via
-    #   awscli-cwlogs
-    #   notifications-utils
+    # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
 billiard==3.6.4.0
@@ -95,7 +93,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.2.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181588331

This is also a good opportunity to remove the redundant egg spec in
the requirements, like we have in other repos.