### PR TITLE
Use `yaml.safe_load` instead of `yaml.load`

### DIFF
--- a/app/models/alerts.py
+++ b/app/models/alerts.py
@@ -83,4 +83,4 @@ class Alerts(SerialisedModelCollection):
     @classmethod
     def from_yaml(cls, path=REPO / 'data.yaml'):
         with path.open() as stream:
-            return yaml.load(stream)['alerts']
+            return yaml.safe_load(stream)['alerts']

--- a/app/models/planned_tests.py
+++ b/app/models/planned_tests.py
@@ -10,6 +10,6 @@ class PlannedTests(SerialisedModelCollection):
 
     @classmethod
     def from_yaml(cls, path=REPO / 'planned-tests.yaml'):
-        data = yaml.load(path.read_bytes())
+        data = yaml.safe_load(path.read_bytes())
 
         return cls(data['planned_tests'])


### PR DESCRIPTION
This fixes the deprecation warning we are seeing in our logs:
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load
for full details.
```

`yaml.load` has some wild features which we are not using, for example being able to create arbitrary Python objects from YAML(!): https://pyyaml.org/wiki/PyYAMLDocumentation#cb13

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
