### PR TITLE
Fix incorrect group for NPM dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ run-flask:
 .PHONY: bootstrap
 bootstrap:
 	pip install -r requirements_for_test.txt
-	source $(HOME)/.nvm/nvm.sh && nvm install && npm ci && npm run build
+	source $(HOME)/.nvm/nvm.sh && nvm install && npm ci --no-audit && npm run build
 
 .PHONY: test
 test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "govuk-frontend": "^4.0.1",
         "html5shiv": "^3.7.3",
         "timeago.js": "^4.0.2"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
-        "govuk-frontend": "^4.0.1",
         "gulp": "^4.0.2",
         "gulp-if": "^3.0.0",
         "gulp-postcss": "^9.0.1",
@@ -5772,7 +5772,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
       "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
-      "dev": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -20378,8 +20377,7 @@
     "govuk-frontend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
-      "dev": true
+      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
     },
     "graceful-fs": {
       "version": "4.2.6",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   "homepage": "https://github.com/alphagov/notifications-govuk-alerts#readme",
   "dependencies": {
     "html5shiv": "^3.7.3",
-    "timeago.js": "^4.0.2"
+    "timeago.js": "^4.0.2",
+    "govuk-frontend": "^4.0.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.3",
-    "govuk-frontend": "^4.0.1",
     "gulp": "^4.0.2",
     "gulp-if": "^3.0.0",
     "gulp-postcss": "^9.0.1",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181889734

This means we can use tools like "npm audit" to look for security
vulnerabilities we definitely need to fix as they could pose a
direct risk to users. I've checked each of them with @tombye and
also against an external set of principles [^1].

[^1]: https://betterprogramming.pub/is-this-a-dependency-or-a-devdependency-678e04a55a5c