### PR TITLE
Bump utils to 56.0.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,4 @@ Flask==1.1.2
 pycurl==7.43.0.6
 awscli-cwlogs>=1.4,<1.5
 notifications-python-client==6.2.1
-git+https://github.com/alphagov/notifications-utils.git@55.2.0
+git+https://github.com/alphagov/notifications-utils.git@56.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.2.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.2
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -113,7 +113,7 @@ pyjwt==2.3.0
     # via notifications-python-client
 pyparsing==3.0.6
     # via packaging
-pypdf2==1.28.4
+pypdf2==2.4.2
     # via notifications-utils
 pyproj==3.2.1
     # via notifications-utils
@@ -158,6 +158,8 @@ smartypants==2.0.1
     # via notifications-utils
 statsd==3.3.0
     # via notifications-utils
+typing-extensions==4.3.0
+    # via pypdf2
 urllib3==1.26.7
     # via
     #   botocore


### PR DESCRIPTION
Brings in fixes for how URLs are linked in alerts
- [x] https://github.com/alphagov/notifications-utils/pull/974
- [x] https://github.com/alphagov/notifications-utils/pull/979

Also some small unrelated changes: https://github.com/alphagov/notifications-utils/compare/55.2.0...56.0.2




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
