### PR TITLE
Increase publish wait time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ cf-run-task-publish: cf-target
 	# successful and return a non-zero status if not;
 	# make doesn't support multiline scripts, so the "\"
 	# and ";" turn it into a oneliner with an exit status
-	for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do \
+	for _ in {1..36}; do \
 		if $(CHECK_COMMAND) | grep SUCCEEDED; then\
 			exit 0; \
 		fi; \


### PR DESCRIPTION
Republishing the static site currently re-renders pages for all
past alerts.

In test environments containing many test alerts, this can cause
the publish task to timeout. This change increases the wait time
to 5 minutes.

Signed-off-by: Richard Baker <richard.baker@digital.cabinet-office.gov.uk>




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
