### PR TITLE
Revise launch date and refine handset terminology

### DIFF
--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -52,13 +52,13 @@
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-l">About Emergency Alerts</h2>
       <p class="govuk-body">
-        Emergency Alerts is a new service from the UK government. It’s expected to launch in autumn 2022.
+        Emergency Alerts is a new service from the UK government. It’s expected to launch in 2022.
       </p>
       <p class="govuk-body">
         Emergency alerts will warn you if there’s a danger to life nearby.
       </p>
       <p class="govuk-body">
-        In an emergency, your phone or tablet will receive an alert with advice about how to stay safe.
+        In an emergency, your mobile phone or tablet will receive an alert with advice about how to stay safe.
       </p>
       <p class="govuk-body">
         <a href="/alerts/when-you-get-an-alert" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">What happens when you get an alert</a>


### PR DESCRIPTION
Make the following text revisions to the 'gov.uk/alerts' landing page:

"It’s expected to launch in autumn 2022" -> "It’s expected to launch in 2022"
"In an emergency, your phone or tablet" -> "In an emergency, your mobile phone or tablet"

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
