### PR TITLE
EAS-454 Content update for gov.uk/alerts pages

### DIFF
--- a/app/templates/views/alert.html
+++ b/app/templates/views/alert.html
@@ -36,7 +36,7 @@
         "href": "/"
       },
       {
-        "text": "Emergency alerts",
+        "text": "Emergency Alerts",
         "href": "/alerts"
       },
       parentBreadcrumb,

--- a/app/templates/views/current-alerts.html
+++ b/app/templates/views/current-alerts.html
@@ -30,7 +30,7 @@
         "href": "/"
       },
       {
-        "text": "Emergency alerts",
+        "text": "Emergency Alerts",
         "href": "/alerts"
       }
     ]

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -52,7 +52,7 @@
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-l">About Emergency Alerts</h2>
       <p class="govuk-body">
-        Emergency Alerts is a new service from the UK government. It’s expected to launch in 2022.
+        Emergency Alerts is a new service from the UK government. It’s expected to launch in 2023.
       </p>
       <p class="govuk-body">
         Emergency alerts will warn you if there’s a danger to life nearby.

--- a/app/templates/views/mobile-network-operator-tests.html
+++ b/app/templates/views/mobile-network-operator-tests.html
@@ -30,7 +30,7 @@
         "href": "/"
       },
       {
-        "text": "Emergency alerts",
+        "text": "Emergency Alerts",
         "href": "/alerts"
       }
     ]
@@ -53,7 +53,10 @@
         If you get an alert, your device may make a loud siren-like sound for about 10 seconds.
       </p>
       <p class="govuk-body">
-        You can <a class="govuk-link" href="/alerts/opt-out#mobile-network-operator-tests">opt out of network operator tests</a>.
+        To opt out of mobile network operator tests, turn off ‘test alerts’ in your settings.
+      </p>
+      <p class="govuk-body">
+        If you still get alerts, contact your device manufacturer for help.
       </p>
     </div>
   </div>

--- a/app/templates/views/opt-out.html
+++ b/app/templates/views/opt-out.html
@@ -40,57 +40,24 @@
         How to opt out of emergency alerts
       </h1>
       <p class="govuk-body">
-        You can opt out of some emergency alerts, but not the most important ones.
+        You can opt out of emergency alerts, but you should keep them switched on for your own safety.
       </p>
       <p class="govuk-body">
         You cannot opt out by subject, only by how serious the emergency is. If you opt out because you do not want flood warnings, for example, you might miss alerts for fires and extreme weather.
       </p>
       <p class="govuk-body">
-        Because of this, you should keep emergency alerts switched on for your own safety.
+        To opt out:
       </p>
-      <h2 class="govuk-heading-l">
-        Android phones and tablets
-      </h2>
+      <ul class="govuk-list govuk-list--number">
+        <li>
+          Search your settings for ‘emergency alerts’
+        </li>
+        <li>
+          Turn off ‘severe alerts’ and ‘extreme alerts’.
+        </li>
+      </ul>
       <p class="govuk-body">
-        To opt out, search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Severe alerts</b>.
-      </p>
-      <p class="govuk-body">
-        If this does not work, contact your device manufacturer.
-      </p>
-      <h3 class="govuk-heading-s" id="mobile-network-operator-tests">
-        Mobile network operator tests
-      </h3>
-      <p class="govuk-body">
-        To opt out of mobile network operator tests, search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
-      </p>
-      {% set testAlertButton %}
-      If you cannot see <b class="govuk-!-font-weight-bold">Test alerts</b>
-      {% endset %}
-      {% set testAlertAdvice %}
-        <ul class="govuk-list govuk-list--number">
-          <li>
-            Open your phone calling app.
-          </li>
-          <li>
-            Use the keypad to enter <span class="govuk-!-font-numeric govuk-!-font-weight-bold">*#*#2627#*#*</span>
-          </li>
-          <li>
-            Search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Test alerts</b>.
-          </li>
-        </ul>
-      {% endset %}
-      {{ govukDetails({
-        "summaryHtml": testAlertButton,
-        "html": testAlertAdvice
-      }) }}
-      <h2 class="govuk-heading-l">
-        iPhone
-      </h2>
-      <p class="govuk-body">
-        To opt out, search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Severe alerts</b>.
-      </p>
-      <p class="govuk-body">
-        If this does not work, contact your device manufacturer.
+        If you still get alerts, contact your device manufacturer for help.
       </p>
     </div>
   </div>

--- a/app/templates/views/past-alerts.html
+++ b/app/templates/views/past-alerts.html
@@ -30,7 +30,7 @@
         "href": "/"
       },
       {
-        "text": "Emergency alerts",
+        "text": "Emergency Alerts",
         "href": "/alerts"
       }
     ]


### PR DESCRIPTION
Content revisions:

- '/alerts' - launch date updated to "2023"
- '/opt-out' - page revised for clarity and brevity
- '/mobile-network-operator-tests' - page revised for clarity and brevity
- Breadcrumbs updated on various pages to correct casing of text.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
