### PR TITLE
EAS-475 Repository to change name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# notifications-govuk-alerts
+# emergency-alerts-govuk
 
 Website for emergency alerts, hosted under /alerts on GOV.UK.
 
@@ -47,7 +47,7 @@ We aim to match the [browsers supported by GOVUK Frontend](https://github.com/al
 
 Any Python code changes you make should be picked up automatically in development. If you're developing JavaScript code, run `npm run watch` to achieve the same.
 
-**This app can also be run as a Celery worker, but this is currently broken on some machines. See https://github.com/alphagov/notifications-govuk-alerts/issues/214**
+**This app can also be run as a Celery worker, but this is currently broken on some machines. See https://github.com/alphagov/emergency-alerts-govuk/issues/214**
 
 ## To test the application
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,9 @@
 import os
 
 from flask import Flask
-from notifications_utils import logging
-from notifications_utils.celery import NotifyCelery
-from notifications_utils.clients.statsd.statsd_client import StatsdClient
+from emergency_alerts_utils import logging
+from emergency_alerts_utils.celery import NotifyCelery
+from emergency_alerts_utils.clients.statsd.statsd_client import StatsdClient
 
 from app.notify_client.alerts_api_client import AlertsApiClient
 from app.utils import DIST

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,9 @@
 import os
 
-from flask import Flask
 from emergency_alerts_utils import logging
 from emergency_alerts_utils.celery import NotifyCelery
 from emergency_alerts_utils.clients.statsd.statsd_client import StatsdClient
+from flask import Flask
 
 from app.notify_client.alerts_api_client import AlertsApiClient
 from app.utils import DIST

--- a/app/models/alert.py
+++ b/app/models/alert.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import pytz
-from notifications_utils.serialised_model import SerialisedModel
+from emergency_alerts_utils.serialised_model import SerialisedModel
 
 from app.models.alert_date import AlertDate
 

--- a/app/models/alert_date.py
+++ b/app/models/alert_date.py
@@ -1,7 +1,7 @@
 import datetime
 
 import pytz
-from notifications_utils.timezones import (
+from emergency_alerts_utils.timezones import (
     local_timezone,
     utc_string_to_aware_gmt_datetime,
 )

--- a/app/models/alerts.py
+++ b/app/models/alerts.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 import yaml
-from notifications_utils.serialised_model import SerialisedModelCollection
+from emergency_alerts_utils.serialised_model import SerialisedModelCollection
 
 from app import alerts_api_client
 from app.models.alert import Alert

--- a/app/models/planned_test.py
+++ b/app/models/planned_test.py
@@ -1,4 +1,4 @@
-from notifications_utils.serialised_model import SerialisedModel
+from emergency_alerts_utils.serialised_model import SerialisedModel
 
 from app.models.alert_date import AlertDate
 

--- a/app/models/planned_tests.py
+++ b/app/models/planned_tests.py
@@ -1,5 +1,5 @@
 import yaml
-from notifications_utils.serialised_model import SerialisedModelCollection
+from emergency_alerts_utils.serialised_model import SerialisedModelCollection
 
 from app.models.planned_test import PlannedTest
 from app.utils import REPO

--- a/app/render.py
+++ b/app/render.py
@@ -1,3 +1,4 @@
+from emergency_alerts_utils.formatters import autolink_urls, formatted_list
 from jinja2 import (
     ChoiceLoader,
     Environment,
@@ -6,7 +7,6 @@ from jinja2 import (
     PrefixLoader,
     contextfilter,
 )
-from emergency_alerts_utils.formatters import autolink_urls, formatted_list
 
 from app.utils import DIST, REPO, file_fingerprint, paragraphize
 

--- a/app/render.py
+++ b/app/render.py
@@ -6,7 +6,7 @@ from jinja2 import (
     PrefixLoader,
     contextfilter,
 )
-from notifications_utils.formatters import autolink_urls, formatted_list
+from emergency_alerts_utils.formatters import autolink_urls, formatted_list
 
 from app.utils import DIST, REPO, file_fingerprint, paragraphize
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ The overall architecture looks like this:
                                        |
                                        v
 +------------------------------+     +-------------------------------+     +--------------------------+
-|                              |     |                               |     |        Notify API        |
+|                              |     |                               |     |         EAS API          |
 | static pages (e.g. homepage) |     |     common rendering code     |     |                          |
 |                              | --> |                               | <-- | dynamic alerts (from DB) |
 +------------------------------+     +-------------------------------+     +--------------------------+
@@ -52,11 +52,11 @@ The overall architecture looks like this:
 
 This app evolved from a handful of scripts generating output files in a `dist/` directory, which were then uploaded to an S3 bucket as part of a Concourse job. The job was also responsible for purging the Fastly CDN to make changes visible quickly. Originally all the alerts on the site were hard-coded in a `data.yaml` file.
 
-In order to show alerts dynamically, we added a Celery task to replace much of the Concourse job, which now builds and uploads static assets to S3, and deploys this repo as a Celery worker. The Celery task fetches alerts from Notify API as a new data source, and is triggered when the app is deployed and when alerts are published.
+In order to show alerts dynamically, we added a Celery task to replace much of the Concourse job, which now builds and uploads static assets to S3, and deploys this repo as a Celery worker. The Celery task fetches alerts from Emergency Alerts API as a new data source, and is triggered when the app is deployed and when alerts are published.
 
 - 👉 [GOV.UK Fastly CDN configuration](https://docs.publishing.service.gov.uk/manual/notify-emergency-alerts.html)
-- 👉 [Concourse deployment pipeline](https://github.com/alphagov/notifications-broadcasts-infra/blob/main/ci/govuk-alerts.yml)
-- 👉 [Terraform for AWS S3, CloudFront, etc.](https://github.com/alphagov/notifications-broadcasts-infra/tree/main/terraform/modules/govuk-alerts-website)
+- 👉 [Concourse deployment pipeline](https://github.com/alphagov/emergency-alerts-infra/blob/main/ci/govuk-alerts.yml)
+- 👉 [Terraform for AWS S3, CloudFront, etc.](https://github.com/alphagov/emergency-alerts-infra/tree/main/terraform/modules/govuk-alerts-website)
 
 In order to support local development, the repo also functions as a Flask app that renders pages on-the-fly and relies on static assets (JS, CSS) being built locally. We could use the Flask app to serve the live site as well, but this would be less robust than the S3 bucket, given the expected traffic patterns for emergency alerts.
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -4,6 +4,6 @@ See [the central documentation about merging and deploying](https://github.com/a
 
 ## Caveats
 
-### The [deployment pipeline](https://github.com/alphagov/notifications-broadcasts-infra/blob/main/ci/govuk-alerts.yml) does't run functional tests for creating / approving alerts.
+### The [deployment pipeline](https://github.com/alphagov/emergency-alerts-infra/blob/main/ci/govuk-alerts.yml) does't run functional tests for creating / approving alerts.
 
 You should manually test any changes that might affect the way the Celery worker runs or consumes from its queue e.g. changes to environment variables. This can be done locally, by deploying a branch or doing non-continuous (manual) deployment.

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -1,6 +1,6 @@
 # Redirects
 
-If you need to set up a new redirect, you can do that in our notifications-broadcasts-infra repository.
+If you need to set up a new redirect, you can do that in our emergency-alerts-infra repository.
 
 In there, head to `terraform/modules/govuk-alerts-website/files/redirects` and add your redirect to REDIRECTS constant, using the following format:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "notifications-govuk-alerts",
+  "name": "emergency-alerts-govuk",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "notifications-govuk-alerts",
+      "name": "emergency-alerts-govuk",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "notifications-govuk-alerts",
+  "name": "emergency-alerts-govuk",
   "version": "0.0.1",
   "description": "Static pages for GOVUK alerts",
   "engines": {
@@ -16,11 +16,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alphagov/notifications-govuk-alerts.git"
+    "url": "git+https://github.com/alphagov/emergency-alerts-govuk.git"
   },
   "author": "Government Digital Service",
   "license": "MIT",
-  "homepage": "https://github.com/alphagov/notifications-govuk-alerts#readme",
+  "homepage": "https://github.com/alphagov/emergency-alerts-govuk#readme",
   "dependencies": {
     "govuk-frontend": "^4.0.1",
     "html5shiv": "^3.7.3",

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,4 @@ Flask==1.1.2
 pycurl==7.43.0.6
 awscli-cwlogs>=1.4,<1.5
 notifications-python-client==6.2.1
-git+https://github.com/alphagov/emergency-alerts-utils.git@56.0.2
+git+https://github.com/alphagov/emergency-alerts-utils.git@60.0.0-alpha

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,4 @@ Flask==1.1.2
 pycurl==7.43.0.6
 awscli-cwlogs>=1.4,<1.5
 notifications-python-client==6.2.1
-git+https://github.com/alphagov/notifications-utils.git@56.0.2
+git+https://github.com/alphagov/emergency-alerts-utils.git@56.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,18 +13,18 @@ awscli-cwlogs==1.4.6
 billiard==3.6.4.0
     # via celery
 bleach==4.1.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 boto3==1.20.26
     # via
     #   -r requirements.in
-    #   notifications-utils
+    #   emergency-alerts-utils
 botocore==1.23.26
     # via
     #   awscli
     #   boto3
     #   s3transfer
 cachetools==5.0.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 celery==5.1.2
     # via -r requirements.in
 certifi==2021.10.8
@@ -58,13 +58,13 @@ flask==1.1.2
     # via
     #   -r requirements.in
     #   flask-redis
-    #   notifications-utils
+    #   emergency-alerts-utils
 flask-redis==0.4.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 geojson==2.5.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 govuk-bank-holidays==0.10
-    # via notifications-utils
+    # via emergency-alerts-utils
 govuk-frontend-jinja==2.0.0
     # via -r requirements.in
 idna==3.3
@@ -72,13 +72,13 @@ idna==3.3
 itsdangerous==2.0.1
     # via
     #   flask
-    #   notifications-utils
+    #   emergency-alerts-utils
 jinja2==2.11.3
     # via
     #   -r requirements.in
     #   flask
     #   govuk-frontend-jinja
-    #   notifications-utils
+    #   emergency-alerts-utils
 jmespath==0.10.0
     # via
     #   boto3
@@ -90,19 +90,19 @@ markupsafe==1.1.1
     #   -r requirements.in
     #   jinja2
 mistune==0.8.4
-    # via notifications-utils
+    # via emergency-alerts-utils
 notifications-python-client==6.2.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.2
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git@56.0.2
     # via -r requirements.in
 orderedset==2.0.3
-    # via notifications-utils
+    # via emergency-alerts-utils
 packaging==21.3
     # via
     #   bleach
     #   redis
 phonenumbers==8.12.40
-    # via notifications-utils
+    # via emergency-alerts-utils
 prompt-toolkit==3.0.24
     # via click-repl
 pyasn1==0.4.8
@@ -114,24 +114,24 @@ pyjwt==2.3.0
 pyparsing==3.0.6
     # via packaging
 pypdf2==2.4.2
-    # via notifications-utils
+    # via emergency-alerts-utils
 pyproj==3.2.1
-    # via notifications-utils
+    # via emergency-alerts-utils
 python-dateutil==2.8.2
     # via
     #   awscli-cwlogs
     #   botocore
 python-json-logger==2.0.2
-    # via notifications-utils
+    # via emergency-alerts-utils
 pytz==2021.3
     # via
     #   celery
-    #   notifications-utils
+    #   emergency-alerts-utils
 pyyaml==5.4.1
     # via
     #   -r requirements.in
     #   awscli
-    #   notifications-utils
+    #   emergency-alerts-utils
 redis==4.1.0
     # via flask-redis
 requests==2.26.0
@@ -139,7 +139,7 @@ requests==2.26.0
     #   awscli-cwlogs
     #   govuk-bank-holidays
     #   notifications-python-client
-    #   notifications-utils
+    #   emergency-alerts-utils
 rsa==4.7.2
     # via awscli
 s3transfer==0.5.0
@@ -147,7 +147,7 @@ s3transfer==0.5.0
     #   awscli
     #   boto3
 shapely==1.8.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 six==1.16.0
     # via
     #   awscli-cwlogs
@@ -155,9 +155,9 @@ six==1.16.0
     #   click-repl
     #   python-dateutil
 smartypants==2.0.1
-    # via notifications-utils
+    # via emergency-alerts-utils
 statsd==3.3.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 typing-extensions==4.3.0
     # via pypdf2
 urllib3==1.26.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ mistune==0.8.4
     # via emergency-alerts-utils
 notifications-python-client==6.2.1
     # via -r requirements.in
-emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git@56.0.2
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git@60.0.0-alpha
     # via -r requirements.in
 orderedset==2.0.3
     # via emergency-alerts-utils


### PR DESCRIPTION
This repository will be changing its name from 'notifications-govuk-alerts' to 'emergency-alerts-govuk'.

This PR is paired with PRs in:
notifications-broadcast-infra [#461](https://github.com/alphagov/notifications-broadcasts-infra/pull/461) (name to be changed to emergency-alerts-infra)
notifications-cbc-proxy [#120](https://github.com/alphagov/notifications-cbc-proxy/pull/120) (name to be changed to emergency-alerts-cbc-proxy)




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
